### PR TITLE
Refactor routing configuration for protected pages

### DIFF
--- a/app/admin/dashboard/CuponsPorDiaChart.tsx
+++ b/app/admin/dashboard/CuponsPorDiaChart.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from "recharts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface CuponsPorDiaChartProps {
+  data: {
+    dia: string;
+    quantidade: number;
+  }[];
+}
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="rounded-md border bg-background px-3 py-2 text-sm shadow-lg">
+        <p className="font-semibold">{label}</p>
+        <p className="text-primary">{`Cupons: ${payload[0].value}`}</p>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default function CuponsPorDiaChart({ data }: CuponsPorDiaChartProps) {
+  const hasData = data && data.length > 0;
+
+  return (
+    <Card className="shadow-sm">
+      <CardHeader>
+        <CardTitle>Cupons emitidos por dia</CardTitle>
+        <CardDescription>Evolução diária dos cupons gerados.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {hasData ? (
+          <ResponsiveContainer width="100%" height={360}>
+            <LineChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+              <XAxis dataKey="dia" tick={{ fontSize: 12 }} />
+              <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+              <Tooltip content={<CustomTooltip />} cursor={{ stroke: "hsl(var(--primary))" }} />
+              <Line
+                type="monotone"
+                dataKey="quantidade"
+                stroke="hsl(var(--primary))"
+                strokeWidth={2}
+                dot={{ r: 3 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex h-[360px] items-center justify-center text-muted-foreground">
+            Nenhum dado de cupons para exibir.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/dashboard/DashboardGraficoFilial.tsx
+++ b/app/admin/dashboard/DashboardGraficoFilial.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from "recharts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface DashboardGraficoFilialProps {
+  data: {
+    filial: string;
+    total: number;
+  }[];
+}
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="rounded-md border bg-background px-3 py-2 text-sm shadow-lg">
+        <p className="font-semibold">{label}</p>
+        <p className="text-primary">{`Notas: ${payload[0].value}`}</p>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default function DashboardGraficoFilial({ data }: DashboardGraficoFilialProps) {
+  const hasData = data && data.length > 0;
+
+  return (
+    <Card className="shadow-sm">
+      <CardHeader>
+        <CardTitle>Notas fiscais por filial</CardTitle>
+        <CardDescription>Distribuição das notas emitidas em cada unidade.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {hasData ? (
+          <ResponsiveContainer width="100%" height={360}>
+            <BarChart data={data}>
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} />
+              <XAxis dataKey="filial" tick={{ fontSize: 12 }} />
+              <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+              <Tooltip content={<CustomTooltip />} cursor={{ fill: "hsl(var(--primary) / 0.1)" }} />
+              <Bar dataKey="total" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex h-[360px] items-center justify-center text-muted-foreground">
+            Nenhum dado de filial para exibir.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/dashboard/StatusCuponsChart.tsx
+++ b/app/admin/dashboard/StatusCuponsChart.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription
+} from "@/components/ui/card";
+import { useTheme } from "next-themes";
+
+interface StatusCuponsChartProps {
+  data: {
+    status: string;
+    quantidade: number;
+  }[];
+}
+
+const BASE_COLORS = {
+  light: {
+    aptos: "hsl(221.2 83.2% 53.3%)",
+    sorteados: "hsl(0 0% 63.9%)"
+  },
+  dark: {
+    aptos: "hsl(217.2 91.2% 59.8%)",
+    sorteados: "hsl(0 0% 63.9%)"
+  }
+};
+
+const RADIAN = Math.PI / 180;
+const renderCustomizedLabel = ({
+  cx,
+  cy,
+  midAngle,
+  innerRadius,
+  outerRadius,
+  percent
+}: any) => {
+  if (percent < 0.05) return null;
+
+  const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+  return (
+    <text
+      x={x}
+      y={y}
+      fill="hsl(var(--primary-foreground))"
+      textAnchor={x > cx ? "start" : "end"}
+      dominantBaseline="central"
+      className="text-xs font-medium"
+    >
+      {`${(percent * 100).toFixed(0)}%`}
+    </text>
+  );
+};
+
+const CustomTooltip = ({ active, payload }: any) => {
+  if (active && payload && payload.length) {
+    const data = payload[0].payload;
+    return (
+      <div className="bg-background border rounded-md shadow-lg px-3 py-2 text-sm">
+        <p className="font-semibold" style={{ color: payload[0].color }}>
+          {data.status}
+        </p>
+        <p>{`Quantidade: ${data.quantidade.toLocaleString("pt-BR")}`}</p>
+        <p className="text-muted-foreground">{`Porcentagem: ${(payload[0].percent * 100).toFixed(1)}%`}</p>
+      </div>
+    );
+  }
+  return null;
+};
+
+export default function StatusCuponsChart({ data }: StatusCuponsChartProps) {
+  const { resolvedTheme } = useTheme();
+  const themeKey = resolvedTheme === "dark" ? "dark" : "light";
+  const colors = BASE_COLORS[themeKey];
+
+  const chartData = data.map((entry) => ({
+    ...entry,
+    fill: entry.status.toLowerCase().includes("apto") ? colors.aptos : colors.sorteados
+  }));
+
+  const hasData = chartData.length > 0;
+
+  return (
+    <Card className="shadow-sm">
+      <CardHeader>
+        <CardTitle>Status dos Cupons</CardTitle>
+        <CardDescription>Proporção de cupons aptos vs. sorteados.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {hasData ? (
+          <ResponsiveContainer width="100%" height={300}>
+            <PieChart>
+              <Tooltip content={<CustomTooltip />} />
+              <Legend
+                wrapperStyle={{ fontSize: "14px", paddingTop: "20px" }}
+                verticalAlign="bottom"
+                align="center"
+              />
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                dataKey="quantidade"
+                nameKey="status"
+                innerRadius={70}
+                outerRadius={110}
+                paddingAngle={2}
+                labelLine={false}
+                label={renderCustomizedLabel}
+              >
+                {chartData.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={entry.fill} stroke={entry.fill} />
+                ))}
+              </Pie>
+            </PieChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex items-center justify-center h-[300px] text-muted-foreground">
+            Nenhum cupom encontrado para exibir status.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/dashboard/TopClientesCuponsChart.tsx
+++ b/app/admin/dashboard/TopClientesCuponsChart.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  LabelList,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from "recharts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface TopClientesCuponsChartProps {
+  data: {
+    nome_cliente: string;
+    quantidade: number;
+  }[];
+}
+
+// Tooltip customizado
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-background border rounded-md shadow-lg px-3 py-2 text-sm">
+        <p className="font-semibold">{label}</p> {/* Mostra o nome do cliente */}
+        <p className="text-primary">{`Cupons: ${payload[0].value}`}</p>
+      </div>
+    );
+  }
+  return null;
+};
+
+// Função para truncar nomes longos no eixo Y
+const formatYAxisLabel = (value: string) => {
+  const maxLength = 25; // Ajuste conforme necessário
+  if (value.length > maxLength) {
+    return `${value.substring(0, maxLength)}...`;
+  }
+  return value;
+};
+
+export default function TopClientesCuponsChart({ data }: TopClientesCuponsChartProps) {
+  const hasData = data && data.length > 0;
+
+  // Inverte os dados para Recharts exibir do maior para o menor em barras horizontais
+  const reversedData = hasData ? [...data].reverse() : [];
+
+  return (
+    <Card className="shadow-sm">
+      <CardHeader>
+        <CardTitle>Top 10 Clientes por Cupons Gerados</CardTitle>
+        <CardDescription>Clientes com maior número de cupons emitidos.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {hasData ? (
+          <ResponsiveContainer width="100%" height={400}>
+            {/* Altura maior para barras horizontais */}
+            <BarChart
+              layout="vertical" // <<< Define como barras horizontais
+              data={reversedData} // <<< Usa dados invertidos
+              margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.3} horizontal={false} />
+              {/* Eixo X (Quantidade) - fica na parte inferior */}
+              <XAxis type="number" allowDecimals={false} tick={{ fontSize: 12 }} />
+              {/* Eixo Y (Nome do Cliente) - fica na esquerda */}
+              <YAxis
+                type="category"
+                dataKey="nome_cliente" // <<< Usa o nome do cliente
+                width={150} // <<< Ajuste a largura para caber nomes
+                tick={{ fontSize: 11 }}
+                tickFormatter={formatYAxisLabel} // <<< Trunca nomes longos
+              />
+              <Tooltip content={<CustomTooltip />} cursor={{ fill: "hsl(var(--primary) / 0.1)" }} />
+              {/* Barra */}
+              <Bar dataKey="quantidade" name="Cupons" fill="hsl(var(--primary))" radius={[0, 4, 4, 0]} maxBarSize={30}>
+                {/* Label DENTRO ou FORA da barra */}
+                <LabelList
+                  dataKey="quantidade"
+                  position="right"
+                  style={{ fill: "hsl(var(--foreground))", fontSize: 11 }}
+                />
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex items-center justify-center h-[400px] text-muted-foreground">
+            Nenhum dado de cliente para exibir.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,0 +1,255 @@
+import "server-only";
+
+import { createClient } from "@supabase/supabase-js";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+import CuponsPorDiaChart from "./CuponsPorDiaChart";
+import TopClientesCuponsChart from "./TopClientesCuponsChart";
+import DashboardGraficoFilial from "./DashboardGraficoFilial";
+
+type KPIStats = {
+  totalCupons: number;
+  totalNotas: number;
+  faturamentoTotal: number;
+};
+
+type CuponsPorDiaData = {
+  dia: string;
+  quantidade: number;
+}[];
+
+type NotasPorFilialData = {
+  filial: string;
+  total: number;
+}[];
+
+// NOVO: Tipo para dados do Top Clientes
+type TopClientesData = {
+  cnpj_cliente: string;
+  nome_cliente: string;
+  quantidade: number;
+}[];
+
+type DashboardLoadResult = {
+  kpis: KPIStats | null;
+  notasPorFilial: NotasPorFilialData;
+  cuponsPorDia: CuponsPorDiaData;
+  topClientes: TopClientesData;
+  errorKpis: Error | null;
+  errorNotasPorFilial: Error | null;
+  errorCuponsPorDia: Error | null;
+  errorTopClientes: Error | null;
+};
+
+function createSupabaseServerClient() {
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseServiceKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    throw new Error("Configurações do Supabase não encontradas para o dashboard administrativo.");
+  }
+
+  return createClient(supabaseUrl, supabaseServiceKey, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  });
+}
+
+async function carregarDashboardDados(): Promise<DashboardLoadResult> {
+  const supabase = createSupabaseServerClient();
+
+  let kpis: KPIStats | null = null;
+  let notasPorFilial: NotasPorFilialData = [];
+  let cuponsPorDia: CuponsPorDiaData = [];
+  let topClientes: TopClientesData = [];
+
+  let errorKpis: Error | null = null;
+  let errorNotasPorFilial: Error | null = null;
+  let errorCuponsPorDia: Error | null = null;
+  let errorTopClientes: Error | null = null;
+
+  try {
+    const { data, error } = await supabase.rpc("get_admin_dashboard_kpis");
+
+    if (error) throw error;
+
+    const payload = (data as Partial<KPIStats>) ?? {};
+
+    kpis = {
+      totalCupons: Number(payload.totalCupons ?? 0),
+      totalNotas: Number(payload.totalNotas ?? 0),
+      faturamentoTotal: Number(payload.faturamentoTotal ?? 0)
+    };
+  } catch (err) {
+    if (err instanceof Error) {
+      console.error("Erro ao buscar KPIs do dashboard:", err);
+      errorKpis = err;
+    }
+  }
+
+  try {
+    const { data, error } = await supabase.rpc("get_notas_por_filial");
+
+    if (error) throw error;
+
+    notasPorFilial = ((data as NotasPorFilialData) ?? []).map((item) => ({
+      filial: String((item as { filial?: string }).filial ?? ""),
+      total: Number((item as { total?: number }).total ?? 0)
+    }));
+  } catch (err) {
+    if (err instanceof Error) {
+      console.error("Erro ao buscar notas por filial:", err);
+      errorNotasPorFilial = err;
+    }
+  }
+
+  try {
+    const { data, error } = await supabase.rpc("get_cupons_por_dia");
+
+    if (error) throw error;
+
+    cuponsPorDia = ((data as CuponsPorDiaData) ?? []).map((item) => ({
+      dia: String((item as { dia?: string }).dia ?? ""),
+      quantidade: Number((item as { quantidade?: number }).quantidade ?? 0)
+    }));
+  } catch (err) {
+    if (err instanceof Error) {
+      console.error("Erro ao buscar cupons por dia:", err);
+      errorCuponsPorDia = err;
+    }
+  }
+
+  // --- BUSCA NOVA: Top Clientes por Cupons ---
+  try {
+    const { data, error } = await supabase.rpc("get_top_clientes_cupons", { limite: 10 });
+
+    if (error) throw error;
+
+    topClientes = ((data as TopClientesData) ?? []).map((item) => ({
+      cnpj_cliente: String((item as { cnpj_cliente?: string }).cnpj_cliente ?? ""),
+      nome_cliente: String((item as { nome_cliente?: string }).nome_cliente ?? ""),
+      quantidade: Number((item as { quantidade?: number }).quantidade ?? 0)
+    }));
+  } catch (err) {
+    if (err instanceof Error) {
+      console.error("Erro ao buscar top clientes por cupons:", err);
+      errorTopClientes = err;
+    }
+  }
+  // --- FIM DA BUSCA NOVA ---
+
+  return {
+    kpis,
+    notasPorFilial,
+    cuponsPorDia,
+    topClientes,
+    errorKpis,
+    errorNotasPorFilial,
+    errorCuponsPorDia,
+    errorTopClientes
+  };
+}
+
+export default async function AdminDashboardPage() {
+  const {
+    kpis,
+    notasPorFilial,
+    cuponsPorDia,
+    topClientes,
+    errorKpis,
+    errorNotasPorFilial,
+    errorCuponsPorDia,
+    errorTopClientes
+  } = await carregarDashboardDados();
+
+  const errors = [errorKpis, errorNotasPorFilial, errorCuponsPorDia, errorTopClientes].filter(
+    Boolean
+  ) as Error[];
+
+  return (
+    <div className="space-y-6">
+      {errors.length > 0 && (
+        <Alert variant="destructive">
+          <AlertTitle>Não foi possível carregar todas as informações</AlertTitle>
+          <AlertDescription>
+            <ul className="list-disc space-y-1 pl-4">
+              {errors.map((error) => (
+                <li key={error.message}>{error.message}</li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle>Cupons emitidos</CardTitle>
+            <CardDescription>Quantidade total de cupons gerados</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <span className="text-3xl font-bold">{kpis?.totalCupons ?? 0}</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Notas fiscais</CardTitle>
+            <CardDescription>Total de notas geradas</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <span className="text-3xl font-bold">{kpis?.totalNotas ?? 0}</span>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Faturamento (R$)</CardTitle>
+            <CardDescription>Receita consolidada</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <span className="text-3xl font-bold">
+              {(kpis?.faturamentoTotal ?? 0).toLocaleString("pt-BR", {
+                style: "currency",
+                currency: "BRL"
+              })}
+            </span>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Gráfico de Cupons por Dia */}
+      {errorCuponsPorDia ? (
+        <Alert variant="destructive">
+          <AlertTitle>Erro ao carregar cupons por dia</AlertTitle>
+          <AlertDescription>{errorCuponsPorDia.message}</AlertDescription>
+        </Alert>
+      ) : (
+        <CuponsPorDiaChart data={cuponsPorDia} />
+      )}
+
+      {/* --- NOVO: Renderização Top Clientes --- */}
+      <div className="grid gap-6 md:grid-cols-2">
+        {errorTopClientes ? (
+          <Alert variant="destructive">
+            <AlertTitle>Erro ao carregar Top Clientes</AlertTitle>
+            <AlertDescription>{errorTopClientes.message}</AlertDescription>
+          </Alert>
+        ) : (
+          <TopClientesCuponsChart data={topClientes} />
+        )}
+        {/* Aqui pode entrar o próximo gráfico (Notas por Valor) */}
+      </div>
+      {/* --- FIM NOVO Top Clientes --- */}
+
+      {/* Gráfico de barras por filial */}
+      {errorNotasPorFilial ? (
+        <Alert variant="destructive">
+          <AlertTitle>Erro ao carregar notas por filial</AlertTitle>
+          <AlertDescription>{errorNotasPorFilial.message}</AlertDescription>
+        </Alert>
+      ) : (
+        <DashboardGraficoFilial data={notasPorFilial} />
+      )}
+    </div>
+  );
+}

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,18 +1,15 @@
 import "server-only";
 
-import { createClient } from "@supabase/supabase-js";
+import { Separator } from "@/components/ui/separator";
+import { createClient } from "@/utils/supabase/server";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Users, Ticket, FileText, TicketCheck, Trophy } from "lucide-react";
 
 import CuponsPorDiaChart from "./CuponsPorDiaChart";
 import TopClientesCuponsChart from "./TopClientesCuponsChart";
+import StatusCuponsChart from "./StatusCuponsChart";
 import DashboardGraficoFilial from "./DashboardGraficoFilial";
-
-type KPIStats = {
-  totalCupons: number;
-  totalNotas: number;
-  faturamentoTotal: number;
-};
 
 type CuponsPorDiaData = {
   dia: string;
@@ -24,69 +21,63 @@ type NotasPorFilialData = {
   total: number;
 }[];
 
-// NOVO: Tipo para dados do Top Clientes
 type TopClientesData = {
   cnpj_cliente: string;
   nome_cliente: string;
   quantidade: number;
 }[];
 
-type DashboardLoadResult = {
-  kpis: KPIStats | null;
-  notasPorFilial: NotasPorFilialData;
-  cuponsPorDia: CuponsPorDiaData;
-  topClientes: TopClientesData;
-  errorKpis: Error | null;
-  errorNotasPorFilial: Error | null;
-  errorCuponsPorDia: Error | null;
-  errorTopClientes: Error | null;
-};
+type StatusCuponsData = {
+  status: string;
+  quantidade: number;
+}[];
 
-function createSupabaseServerClient() {
-  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseServiceKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+type DashboardError = { message: string };
 
-  if (!supabaseUrl || !supabaseServiceKey) {
-    throw new Error("Configurações do Supabase não encontradas para o dashboard administrativo.");
-  }
+export default async function AdminDashboardPage() {
+  const supabase = await createClient();
 
-  return createClient(supabaseUrl, supabaseServiceKey, {
-    auth: { persistSession: false, autoRefreshToken: false }
-  });
-}
+  const [
+    usuariosResponse,
+    notasResponse,
+    cuponsResponse,
+    cuponsAptosResponse,
+    cuponsSorteadosResponse
+  ] = await Promise.all([
+    supabase.from("usuarios").select("*", { count: "exact", head: true }),
+    supabase.from("notas_fiscais").select("*", { count: "exact", head: true }),
+    supabase.from("cupons").select("*", { count: "exact", head: true }),
+    supabase
+      .from("cupons")
+      .select("*", { count: "exact", head: true })
+      .is("sorteado_em", null),
+    supabase
+      .from("cupons")
+      .select("*", { count: "exact", head: true })
+      .not("sorteado_em", "is", null)
+  ]);
 
-async function carregarDashboardDados(): Promise<DashboardLoadResult> {
-  const supabase = createSupabaseServerClient();
+  const totalUsuarios = usuariosResponse.count ?? 0;
+  const totalNotas = notasResponse.count ?? 0;
+  const totalCupons = cuponsResponse.count ?? 0;
+  const totalCuponsAptos = cuponsAptosResponse.count ?? 0;
+  const totalCuponsSorteados = cuponsSorteadosResponse.count ?? 0;
 
-  let kpis: KPIStats | null = null;
+  const errorUsuarios = usuariosResponse.error;
+  const errorNotas = notasResponse.error;
+  const errorCupons = cuponsResponse.error;
+  const errorCuponsAptos = cuponsAptosResponse.error;
+  const errorCuponsSorteados = cuponsSorteadosResponse.error;
+
   let notasPorFilial: NotasPorFilialData = [];
   let cuponsPorDia: CuponsPorDiaData = [];
-  let topClientes: TopClientesData = [];
+  let topClientesData: TopClientesData = [];
+  let statusCuponsData: StatusCuponsData = [];
 
-  let errorKpis: Error | null = null;
-  let errorNotasPorFilial: Error | null = null;
-  let errorCuponsPorDia: Error | null = null;
-  let errorTopClientes: Error | null = null;
-
-  try {
-    const { data, error } = await supabase.rpc("get_admin_dashboard_kpis");
-
-    if (error) throw error;
-
-    const payload = (data as Partial<KPIStats>) ?? {};
-
-    kpis = {
-      totalCupons: Number(payload.totalCupons ?? 0),
-      totalNotas: Number(payload.totalNotas ?? 0),
-      faturamentoTotal: Number(payload.faturamentoTotal ?? 0)
-    };
-  } catch (err) {
-    if (err instanceof Error) {
-      console.error("Erro ao buscar KPIs do dashboard:", err);
-      errorKpis = err;
-    }
-  }
+  let errorNotasPorFilial: DashboardError | null = null;
+  let errorCuponsPorDia: DashboardError | null = null;
+  let errorTopClientes: DashboardError | null = null;
+  let errorStatusCupons: DashboardError | null = null;
 
   try {
     const { data, error } = await supabase.rpc("get_notas_por_filial");
@@ -97,11 +88,9 @@ async function carregarDashboardDados(): Promise<DashboardLoadResult> {
       filial: String((item as { filial?: string }).filial ?? ""),
       total: Number((item as { total?: number }).total ?? 0)
     }));
-  } catch (err) {
-    if (err instanceof Error) {
-      console.error("Erro ao buscar notas por filial:", err);
-      errorNotasPorFilial = err;
-    }
+  } catch (err: any) {
+    console.error("Erro ao buscar notas por filial:", err);
+    errorNotasPorFilial = { message: err?.message ?? "Erro ao buscar notas por filial." };
   }
 
   try {
@@ -113,62 +102,68 @@ async function carregarDashboardDados(): Promise<DashboardLoadResult> {
       dia: String((item as { dia?: string }).dia ?? ""),
       quantidade: Number((item as { quantidade?: number }).quantidade ?? 0)
     }));
-  } catch (err) {
-    if (err instanceof Error) {
-      console.error("Erro ao buscar cupons por dia:", err);
-      errorCuponsPorDia = err;
-    }
+  } catch (err: any) {
+    console.error("Erro ao buscar cupons por dia:", err);
+    errorCuponsPorDia = { message: err?.message ?? "Erro ao buscar cupons por dia." };
   }
 
-  // --- BUSCA NOVA: Top Clientes por Cupons ---
   try {
     const { data, error } = await supabase.rpc("get_top_clientes_cupons", { limite: 10 });
 
     if (error) throw error;
 
-    topClientes = ((data as TopClientesData) ?? []).map((item) => ({
+    topClientesData = ((data as TopClientesData) ?? []).map((item) => ({
       cnpj_cliente: String((item as { cnpj_cliente?: string }).cnpj_cliente ?? ""),
       nome_cliente: String((item as { nome_cliente?: string }).nome_cliente ?? ""),
       quantidade: Number((item as { quantidade?: number }).quantidade ?? 0)
     }));
-  } catch (err) {
-    if (err instanceof Error) {
-      console.error("Erro ao buscar top clientes por cupons:", err);
-      errorTopClientes = err;
-    }
+  } catch (err: any) {
+    console.error("Erro ao buscar top clientes por cupons:", err);
+    errorTopClientes = { message: err?.message ?? "Erro ao buscar top clientes." };
   }
-  // --- FIM DA BUSCA NOVA ---
 
-  return {
-    kpis,
-    notasPorFilial,
-    cuponsPorDia,
-    topClientes,
-    errorKpis,
+  try {
+    const { data, error } = await supabase.rpc("get_status_cupons");
+
+    if (error) throw error;
+
+    statusCuponsData = ((data as StatusCuponsData) ?? []).map((item) => ({
+      status: String((item as { status?: string }).status ?? ""),
+      quantidade: Number((item as { quantidade?: number }).quantidade ?? 0)
+    }));
+  } catch (err: any) {
+    console.error("Erro ao buscar status dos cupons:", err);
+    errorStatusCupons = { message: err?.message ?? "Erro ao buscar status dos cupons." };
+  }
+
+  const errors = [
+    errorUsuarios,
+    errorNotas,
+    errorCupons,
+    errorCuponsAptos,
+    errorCuponsSorteados,
     errorNotasPorFilial,
     errorCuponsPorDia,
-    errorTopClientes
-  };
-}
-
-export default async function AdminDashboardPage() {
-  const {
-    kpis,
-    notasPorFilial,
-    cuponsPorDia,
-    topClientes,
-    errorKpis,
-    errorNotasPorFilial,
-    errorCuponsPorDia,
-    errorTopClientes
-  } = await carregarDashboardDados();
-
-  const errors = [errorKpis, errorNotasPorFilial, errorCuponsPorDia, errorTopClientes].filter(
-    Boolean
-  ) as Error[];
+    errorTopClientes,
+    errorStatusCupons
+  ]
+    .filter(Boolean)
+    .map((err) => {
+      if (err instanceof Error) return err;
+      return new Error((err as DashboardError).message);
+    });
 
   return (
     <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold tracking-tight">Dashboard administrativo</h1>
+        <p className="text-muted-foreground">
+          Acompanhe o desempenho de usuários, notas fiscais e cupons da campanha.
+        </p>
+      </div>
+
+      <Separator />
+
       {errors.length > 0 && (
         <Alert variant="destructive">
           <AlertTitle>Não foi possível carregar todas as informações</AlertTitle>
@@ -182,42 +177,73 @@ export default async function AdminDashboardPage() {
         </Alert>
       )}
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardTitle>Cupons emitidos</CardTitle>
-            <CardDescription>Quantidade total de cupons gerados</CardDescription>
+      <div className="grid gap-4 md:grid-cols-3 lg:grid-cols-5">
+        <Card className="shadow-sm">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Usuários</CardTitle>
+            <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <span className="text-3xl font-bold">{kpis?.totalCupons ?? 0}</span>
+            <div className="text-2xl font-bold">
+              {errorUsuarios ? "Erro" : totalUsuarios.toLocaleString("pt-BR")}
+            </div>
+            <CardDescription>Usuários cadastrados na plataforma</CardDescription>
           </CardContent>
         </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Notas fiscais</CardTitle>
-            <CardDescription>Total de notas geradas</CardDescription>
+
+        <Card className="shadow-sm">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Notas fiscais</CardTitle>
+            <FileText className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <span className="text-3xl font-bold">{kpis?.totalNotas ?? 0}</span>
+            <div className="text-2xl font-bold">
+              {errorNotas ? "Erro" : totalNotas.toLocaleString("pt-BR")}
+            </div>
+            <CardDescription>Documentos fiscais registrados</CardDescription>
           </CardContent>
         </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Faturamento (R$)</CardTitle>
-            <CardDescription>Receita consolidada</CardDescription>
+
+        <Card className="shadow-sm">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Cupons emitidos</CardTitle>
+            <Ticket className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <span className="text-3xl font-bold">
-              {(kpis?.faturamentoTotal ?? 0).toLocaleString("pt-BR", {
-                style: "currency",
-                currency: "BRL"
-              })}
-            </span>
+            <div className="text-2xl font-bold">
+              {errorCupons ? "Erro" : totalCupons.toLocaleString("pt-BR")}
+            </div>
+            <CardDescription>Cupons gerados para os clientes</CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card className="shadow-sm">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Cupons aptos</CardTitle>
+            <TicketCheck className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {errorCuponsAptos ? "Erro" : totalCuponsAptos.toLocaleString("pt-BR")}
+            </div>
+            <p className="text-xs text-muted-foreground">Aguardando sorteio</p>
+          </CardContent>
+        </Card>
+
+        <Card className="shadow-sm">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Cupons sorteados</CardTitle>
+            <Trophy className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {errorCuponsSorteados ? "Erro" : totalCuponsSorteados.toLocaleString("pt-BR")}
+            </div>
+            <p className="text-xs text-muted-foreground">Já contemplados</p>
           </CardContent>
         </Card>
       </div>
 
-      {/* Gráfico de Cupons por Dia */}
       {errorCuponsPorDia ? (
         <Alert variant="destructive">
           <AlertTitle>Erro ao carregar cupons por dia</AlertTitle>
@@ -227,21 +253,26 @@ export default async function AdminDashboardPage() {
         <CuponsPorDiaChart data={cuponsPorDia} />
       )}
 
-      {/* --- NOVO: Renderização Top Clientes --- */}
-      <div className="grid gap-6 md:grid-cols-2">
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         {errorTopClientes ? (
           <Alert variant="destructive">
             <AlertTitle>Erro ao carregar Top Clientes</AlertTitle>
             <AlertDescription>{errorTopClientes.message}</AlertDescription>
           </Alert>
         ) : (
-          <TopClientesCuponsChart data={topClientes} />
+          <TopClientesCuponsChart data={topClientesData} />
         )}
-        {/* Aqui pode entrar o próximo gráfico (Notas por Valor) */}
-      </div>
-      {/* --- FIM NOVO Top Clientes --- */}
 
-      {/* Gráfico de barras por filial */}
+        {errorStatusCupons ? (
+          <Alert variant="destructive">
+            <AlertTitle>Erro ao carregar Status dos Cupons</AlertTitle>
+            <AlertDescription>{errorStatusCupons.message}</AlertDescription>
+          </Alert>
+        ) : (
+          <StatusCuponsChart data={statusCuponsData} />
+        )}
+      </div>
+
       {errorNotasPorFilial ? (
         <Alert variant="destructive">
           <AlertTitle>Erro ao carregar notas por filial</AlertTitle>

--- a/src/components/auth/AuthRedirect.jsx
+++ b/src/components/auth/AuthRedirect.jsx
@@ -1,12 +1,35 @@
-import React, { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { useEffect, useRef, useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '@/contexts/SimpleAuthContext'
 import { Loader2 } from 'lucide-react'
 
 export default function AuthRedirect() {
-  const { user, profile, isAuthenticated, isSuperAdmin, loading } = useAuth()
+  const { profile, isAuthenticated, isSuperAdmin, loading } = useAuth()
   const [hasRedirected, setHasRedirected] = useState(false)
   const navigate = useNavigate()
+  const location = useLocation()
+  const originPath = location.state?.from?.pathname || null
+  const profileTimeoutRef = useRef(null)
+  const hasRedirectedRef = useRef(false)
+
+  useEffect(() => {
+    return () => {
+      if (profileTimeoutRef.current) {
+        clearTimeout(profileTimeoutRef.current)
+        profileTimeoutRef.current = null
+      }
+    }
+  }, [])
+
+  const performRedirect = (path) => {
+    if (hasRedirectedRef.current) {
+      return
+    }
+
+    hasRedirectedRef.current = true
+    setHasRedirected(true)
+    navigate(path, { replace: true })
+  }
 
   useEffect(() => {
     // Evitar múltiplos redirecionamentos
@@ -18,59 +41,81 @@ export default function AuthRedirect() {
       return
     }
 
-    console.log('Estado atual:', { isAuthenticated, isSuperAdmin, profile: !!profile, loading, user: !!user })
+    console.log('Estado atual:', { isAuthenticated, isSuperAdmin, profile: !!profile, loading })
 
     // Aguardar um pouco mais para garantir que o estado foi atualizado após login
     const timeout = setTimeout(() => {
-      console.log('Estado após timeout:', { isAuthenticated, isSuperAdmin, profile: !!profile, loading, user: !!user })
+      console.log('Estado após timeout:', { isAuthenticated, isSuperAdmin, profile: !!profile, loading })
 
       // Se não estiver autenticado, ir para login
       if (!isAuthenticated) {
         console.log('Usuário não autenticado, redirecionando para login')
-        setHasRedirected(true)
-        navigate('/login')
+        performRedirect('/login')
         return
       }
 
       // Se não tem perfil ainda, aguardar mais um pouco
       if (!profile) {
         console.log('Aguardando perfil...')
+
+        if (profileTimeoutRef.current) {
+          clearTimeout(profileTimeoutRef.current)
+        }
+
         // Aguardar até 3 segundos pelo perfil
-        const profileTimeout = setTimeout(() => {
+        profileTimeoutRef.current = setTimeout(() => {
           console.log('Timeout aguardando perfil, redirecionando para login')
-          setHasRedirected(true)
-          navigate('/login')
+          performRedirect('/login')
         }, 3000)
-        
-        return () => clearTimeout(profileTimeout)
+
+        return
+      }
+
+      if (profileTimeoutRef.current) {
+        clearTimeout(profileTimeoutRef.current)
+        profileTimeoutRef.current = null
       }
 
       console.log('Perfil carregado:', profile.role)
-      setHasRedirected(true)
+
+      // Priorizar retorno para rota original se houver
+      if (originPath) {
+        console.log('Redirecionando para rota original:', originPath)
+        performRedirect(originPath)
+        return
+      }
 
       // Se for super admin, ir direto para o dashboard de admin
       if (isSuperAdmin) {
         console.log('Redirecionando super admin para dashboard de admin')
-        navigate('/admin/dashboard')
+        performRedirect('/admin/dashboard')
         return
       }
 
       // Verificar se há uma filial selecionada
       const selectedCompany = localStorage.getItem('selectedCompany')
-      
+
       if (selectedCompany) {
         // Se há filial selecionada, ir para o dashboard normal
         console.log('Redirecionando para dashboard com filial selecionada')
-        navigate('/dashboard')
+        performRedirect('/dashboard')
       } else {
         // Se não há filial selecionada, ir para seleção de filial
         console.log('Redirecionando para seleção de filial')
-        navigate('/select-company')
+        performRedirect('/select-company')
       }
     }, 200) // Aguardar 200ms para garantir que o estado foi atualizado
 
     return () => clearTimeout(timeout)
-  }, [isAuthenticated, isSuperAdmin, profile, loading, navigate, hasRedirected, user])
+  }, [
+    hasRedirected,
+    isAuthenticated,
+    isSuperAdmin,
+    loading,
+    navigate,
+    originPath,
+    profile,
+  ])
 
   if (loading) {
     return (

--- a/src/components/finance/ContasAPagarAdvanced.jsx
+++ b/src/components/finance/ContasAPagarAdvanced.jsx
@@ -1,26 +1,29 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { 
-  Plus, 
-  Search, 
-  Filter, 
-  Download, 
-  Eye, 
-  Edit, 
+import {
+  Plus,
+  Search,
+  Filter,
+  Download,
+  Eye,
+  Edit,
   CheckCircle,
   AlertTriangle,
   Calendar,
   DollarSign,
-  CreditCard
+  CreditCard,
+  Upload
 } from 'lucide-react';
 import unifiedFinancialService from '@/api/unifiedFinancialService';
 import ContaAPagarForm from './ContaAPagarForm';
 import PagarContaModal from './PagarContaModal';
+import importService from '@/services/importService';
+import { parseFinancialTransactionsCSV } from '@/utils/importParsers';
 
 export default function ContasAPagarAdvanced({ companyId }) {
   const [contas, setContas] = useState([]);
@@ -36,6 +39,8 @@ export default function ContasAPagarAdvanced({ companyId }) {
     dateFrom: '',
     dateTo: ''
   });
+  const fileInputRef = useRef(null);
+  const [isImporting, setIsImporting] = useState(false);
 
   useEffect(() => {
     if (companyId) {
@@ -155,6 +160,75 @@ export default function ContasAPagarAdvanced({ companyId }) {
     loadContas();
   };
 
+  const handleImportClick = () => {
+    if (!companyId) {
+      alert('Selecione uma empresa antes de importar as contas.');
+      return;
+    }
+
+    fileInputRef.current?.click();
+  };
+
+  const handleFileImport = async (event) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (!companyId) {
+      alert('Selecione uma empresa antes de importar as contas.');
+      event.target.value = '';
+      return;
+    }
+
+    setIsImporting(true);
+
+    try {
+      const text = await file.text();
+      const parsedTransactions = parseFinancialTransactionsCSV(text);
+
+      if (parsedTransactions.length === 0) {
+        alert('Nenhuma conta válida encontrada no arquivo selecionado.');
+        return;
+      }
+
+      const validationErrors = importService.validateData(parsedTransactions, 'financial_transactions');
+
+      if (validationErrors.length > 0) {
+        const formatted = validationErrors
+          .slice(0, 5)
+          .map((error) => `Linha ${error.row}: ${error.errors.join(', ')}`)
+          .join('\n');
+
+        const suffix = validationErrors.length > 5 ? '\n... (corrija os demais registros e tente novamente)' : '';
+        alert(`Erros de validação encontrados:\n${formatted}${suffix}`);
+        return;
+      }
+
+      const results = await importService.importFinancialTransactions(parsedTransactions, companyId);
+
+      await loadContas();
+
+      const summary = [
+        `Contas importadas: ${results.success}/${results.total}`,
+        results.errors ? `Registros com erro: ${results.errors}` : null
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+      alert(`Importação de contas concluída!\n${summary}`);
+    } catch (error) {
+      console.error('Erro ao importar contas a pagar:', error);
+      alert(`Falha ao importar contas: ${error.message}`);
+    } finally {
+      setIsImporting(false);
+      if (event.target) {
+        event.target.value = '';
+      }
+    }
+  };
+
   const formatCurrency = (value) => {
     return new Intl.NumberFormat('pt-BR', {
       style: 'currency',
@@ -203,6 +277,13 @@ export default function ContasAPagarAdvanced({ companyId }) {
 
   return (
     <div className="space-y-6">
+      <input
+        type="file"
+        ref={fileInputRef}
+        accept=".csv"
+        onChange={handleFileImport}
+        className="hidden"
+      />
       {/* Cabeçalho com Estatísticas */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card>
@@ -268,6 +349,10 @@ export default function ContasAPagarAdvanced({ companyId }) {
           <div className="flex items-center justify-between">
             <CardTitle>Contas a Pagar</CardTitle>
             <div className="flex gap-2">
+              <Button variant="outline" size="sm" onClick={handleImportClick} disabled={isImporting}>
+                <Upload className="h-4 w-4 mr-2" />
+                {isImporting ? 'Importando...' : 'Importar CSV'}
+              </Button>
               <Button variant="outline" size="sm">
                 <Download className="h-4 w-4 mr-2" />
                 Exportar

--- a/src/components/warehouse/StockEntryForm.jsx
+++ b/src/components/warehouse/StockEntryForm.jsx
@@ -64,9 +64,10 @@ export default function StockEntryForm({ entry, products, onSubmit, onCancel }) 
   };
 
   const handleSelectChange = (field, value) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
+    const normalizedValue = field === 'product_id' ? Number(value) : value;
+    setFormData(prev => ({ ...prev, [field]: normalizedValue }));
     if (field === 'product_id') {
-      const product = products.find(p => p.id === value);
+      const product = products.find(p => p.id === normalizedValue);
       if (product) {
         setFormData(prev => ({
           ...prev,

--- a/src/components/warehouse/StockFlowDashboard.jsx
+++ b/src/components/warehouse/StockFlowDashboard.jsx
@@ -105,12 +105,13 @@ export default function StockFlowDashboard({ metrics, productBreakdown, timeline
                     <th className="px-4 py-3 font-semibold">Disponível Bruto (t)</th>
                     <th className="px-4 py-3 font-semibold">Processado (t)</th>
                     <th className="px-4 py-3 font-semibold">Comprometido (t)</th>
+                    <th className="px-4 py-3 font-semibold">Disponível Líquido (t)</th>
                   </tr>
                 </thead>
                 <tbody>
                   {productBreakdown.length === 0 && (
                     <tr>
-                      <td colSpan={5} className="px-4 py-6 text-center text-slate-500">
+                      <td colSpan={6} className="px-4 py-6 text-center text-slate-500">
                         Nenhum movimento registrado até o momento.
                       </td>
                     </tr>
@@ -130,6 +131,9 @@ export default function StockFlowDashboard({ metrics, productBreakdown, timeline
                       </td>
                       <td className="px-4 py-3 text-orange-600 font-medium">
                         {formatTonnage(product.committed)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-800 font-semibold">
+                        {formatTonnage(product.netFinishedAvailable)}
                       </td>
                     </tr>
                   ))}

--- a/src/components/warehouse/StockFlowDashboard.jsx
+++ b/src/components/warehouse/StockFlowDashboard.jsx
@@ -1,0 +1,173 @@
+import React from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { TrendingUp, Ship, Warehouse, Package, Truck, Clock } from "lucide-react";
+
+const metricConfig = [
+  {
+    key: "totalPurchasedTonnage",
+    label: "Comprado (t)",
+    description: "Carga total contratada em balsas",
+    icon: Ship,
+    tone: "text-slate-700",
+  },
+  {
+    key: "totalUnloadedTonnage",
+    label: "Descarga (t)",
+    description: "Toneladas já descarregadas no pátio",
+    icon: Warehouse,
+    tone: "text-emerald-600",
+  },
+  {
+    key: "inTransitTonnage",
+    label: "Em Trânsito (t)",
+    description: "Saldo ainda embarcado aguardando descarga",
+    icon: Clock,
+    tone: "text-blue-600",
+  },
+  {
+    key: "rawYardInventory",
+    label: "Estoque Bruto (t)",
+    description: "Matéria-prima disponível para beneficiamento",
+    icon: Package,
+    tone: "text-amber-600",
+  },
+  {
+    key: "finishedYardInventory",
+    label: "Estoque Processado (t)",
+    description: "Calcário pronto para expedição",
+    icon: TrendingUp,
+    tone: "text-emerald-700",
+  },
+  {
+    key: "scheduledOutboundTonnage",
+    label: "Saídas Agendadas (t)",
+    description: "Pedidos liberados aguardando transporte",
+    icon: Truck,
+    tone: "text-orange-600",
+  },
+];
+
+const timelineBadges = {
+  purchase: { tone: "bg-blue-50 text-blue-700", label: "Compra" },
+  unload: { tone: "bg-emerald-50 text-emerald-700", label: "Descarga" },
+  processing: { tone: "bg-amber-50 text-amber-700", label: "Processo" },
+  outbound: { tone: "bg-slate-100 text-slate-700", label: "Saída" },
+};
+
+function formatTonnage(value) {
+  return new Intl.NumberFormat("pt-BR", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export default function StockFlowDashboard({ metrics, productBreakdown, timelineEvents }) {
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-3 gap-6 mb-8">
+      <Card className="xl:col-span-2 border-0 shadow-lg bg-white/70 backdrop-blur-sm">
+        <CardHeader>
+          <CardTitle>Fluxo Operacional do Calcário</CardTitle>
+          <CardDescription>
+            Controle integrado das balsas compradas, descargas, processamento e expedição.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {metricConfig.map((metric) => {
+              const Icon = metric.icon;
+              return (
+                <div key={metric.key} className="p-4 rounded-lg border border-slate-100 bg-white shadow-sm">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-sm font-medium text-slate-500">{metric.label}</span>
+                    <Icon className={`w-4 h-4 ${metric.tone}`} />
+                  </div>
+                  <p className="text-2xl font-semibold text-slate-900">
+                    {formatTonnage(metrics[metric.key] || 0)}
+                  </p>
+                  <p className="text-xs text-slate-500 mt-1">{metric.description}</p>
+                </div>
+              );
+            })}
+          </div>
+
+          <Separator className="my-6" />
+
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 mb-3">Saldo por Produto</h3>
+            <div className="overflow-x-auto rounded-lg border border-slate-100">
+              <table className="w-full text-sm">
+                <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+                  <tr>
+                    <th className="px-4 py-3 font-semibold">Produto</th>
+                    <th className="px-4 py-3 font-semibold">Comprado Bruto (t)</th>
+                    <th className="px-4 py-3 font-semibold">Disponível Bruto (t)</th>
+                    <th className="px-4 py-3 font-semibold">Processado (t)</th>
+                    <th className="px-4 py-3 font-semibold">Comprometido (t)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {productBreakdown.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="px-4 py-6 text-center text-slate-500">
+                        Nenhum movimento registrado até o momento.
+                      </td>
+                    </tr>
+                  )}
+                  {productBreakdown.map((product) => (
+                    <tr key={product.product_id} className="border-t border-slate-100">
+                      <td className="px-4 py-3">
+                        <div className="font-medium text-slate-900">{product.product_name}</div>
+                        <p className="text-xs text-slate-500">ID #{product.product_id}</p>
+                      </td>
+                      <td className="px-4 py-3 text-slate-700">{formatTonnage(product.rawPurchased)}</td>
+                      <td className="px-4 py-3 text-emerald-700 font-medium">
+                        {formatTonnage(product.rawAvailable)}
+                      </td>
+                      <td className="px-4 py-3 text-blue-700 font-medium">
+                        {formatTonnage(product.finishedAvailable)}
+                      </td>
+                      <td className="px-4 py-3 text-orange-600 font-medium">
+                        {formatTonnage(product.committed)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-0 shadow-lg bg-white/70 backdrop-blur-sm">
+        <CardHeader>
+          <CardTitle>Linha do Tempo Operacional</CardTitle>
+          <CardDescription>Principais eventos da compra à expedição.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4 max-h-[420px] overflow-y-auto pr-1">
+            {timelineEvents.length === 0 && (
+              <p className="text-sm text-slate-500">Ainda não há eventos registrados.</p>
+            )}
+            {timelineEvents.map((event, index) => {
+              const badge = timelineBadges[event.type] || timelineBadges.outbound;
+              return (
+                <div key={`${event.label}-${index}`} className="p-3 rounded-lg border border-slate-100 bg-white shadow-sm">
+                  <div className="flex items-center justify-between">
+                    <Badge className={`${badge.tone} font-medium`}>{badge.label}</Badge>
+                    <span className="text-xs text-slate-500">
+                      {event.date ? event.date.toLocaleDateString("pt-BR") : "Data não informada"}
+                    </span>
+                  </div>
+                  <p className="text-sm font-semibold text-slate-900 mt-2">{event.label}</p>
+                  <p className="text-xs text-slate-600 leading-relaxed">{event.description}</p>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/hooks/useInventoryFlow.js
+++ b/src/hooks/useInventoryFlow.js
@@ -1,0 +1,191 @@
+import { useMemo } from "react";
+
+function sumBy(items, selector) {
+  return items.reduce((total, item) => total + (selector(item) || 0), 0);
+}
+
+function normalizeDate(value) {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function useInventoryFlow({
+  bargeLoads = [],
+  unloadingTrips = [],
+  processingBatches = [],
+  outboundShipments = [],
+}) {
+  return useMemo(() => {
+    const totalPurchasedTonnage = sumBy(bargeLoads, (item) => item.total_tonnage);
+    const totalUnloadedTonnage = sumBy(unloadingTrips, (item) => item.tonnage);
+    const totalProcessingConsumption = sumBy(processingBatches, (item) => item.tonnage_consumed);
+    const totalProcessedTonnage = sumBy(processingBatches, (item) => item.tonnage_produced);
+
+    const totalOutboundTonnage = sumBy(
+      outboundShipments.filter((shipment) => shipment.status !== "cancelled"),
+      (item) => item.tonnage,
+    );
+
+    const scheduledOutboundTonnage = sumBy(
+      outboundShipments.filter((shipment) => shipment.status === "scheduled"),
+      (item) => item.tonnage,
+    );
+
+    const deliveredOutboundTonnage = sumBy(
+      outboundShipments.filter((shipment) => shipment.status === "completed"),
+      (item) => item.tonnage,
+    );
+
+    const inTransitTonnage = Math.max(totalPurchasedTonnage - totalUnloadedTonnage, 0);
+    const rawYardInventory = Math.max(totalUnloadedTonnage - totalProcessingConsumption, 0);
+    const finishedYardInventory = Math.max(totalProcessedTonnage - deliveredOutboundTonnage, 0);
+
+    const productBreakdown = [];
+    const productMap = new Map();
+
+    bargeLoads.forEach((barge) => {
+      if (!productMap.has(barge.product_id)) {
+        productMap.set(barge.product_id, {
+          product_id: barge.product_id,
+          product_name: barge.product_name,
+          rawPurchased: 0,
+          rawAvailable: 0,
+          finishedAvailable: 0,
+          committed: 0,
+        });
+      }
+      const productEntry = productMap.get(barge.product_id);
+      productEntry.rawPurchased += barge.total_tonnage || 0;
+    });
+
+    unloadingTrips.forEach((trip) => {
+      const productEntry = productMap.get(trip.product_id);
+      if (productEntry) {
+        productEntry.rawAvailable += trip.tonnage || 0;
+      }
+    });
+
+    processingBatches.forEach((batch) => {
+      const rawProduct = productMap.get(batch.raw_product_id);
+      if (rawProduct) {
+        rawProduct.rawAvailable -= batch.tonnage_consumed || 0;
+      }
+
+      if (!productMap.has(batch.finished_product_id)) {
+        productMap.set(batch.finished_product_id, {
+          product_id: batch.finished_product_id,
+          product_name: batch.finished_product_name,
+          rawPurchased: 0,
+          rawAvailable: 0,
+          finishedAvailable: 0,
+          committed: 0,
+        });
+      }
+
+      const finishedProduct = productMap.get(batch.finished_product_id);
+      finishedProduct.finishedAvailable += batch.tonnage_produced || 0;
+    });
+
+    outboundShipments.forEach((shipment) => {
+      if (!productMap.has(shipment.product_id)) {
+        productMap.set(shipment.product_id, {
+          product_id: shipment.product_id,
+          product_name: shipment.product_name,
+          rawPurchased: 0,
+          rawAvailable: 0,
+          finishedAvailable: 0,
+          committed: 0,
+        });
+      }
+
+      const productEntry = productMap.get(shipment.product_id);
+      if (shipment.status === "completed") {
+        productEntry.finishedAvailable -= shipment.tonnage || 0;
+      } else if (shipment.status === "scheduled") {
+        productEntry.committed += shipment.tonnage || 0;
+      }
+    });
+
+    productMap.forEach((value) => {
+      productBreakdown.push({
+        ...value,
+        rawAvailable: Number(value.rawAvailable.toFixed(2)),
+        rawPurchased: Number(value.rawPurchased.toFixed(2)),
+        finishedAvailable: Number(value.finishedAvailable.toFixed(2)),
+        committed: Number(value.committed.toFixed(2)),
+      });
+    });
+
+    productBreakdown.sort((a, b) => a.product_name.localeCompare(b.product_name));
+
+    const timelineEvents = [];
+
+    bargeLoads.forEach((barge) => {
+      const date = normalizeDate(barge.purchase_date);
+      timelineEvents.push({
+        type: "purchase",
+        date,
+        label: `Compra ${barge.barge_code}`,
+        description: `${barge.total_tonnage} t de ${barge.product_name} do fornecedor ${barge.supplier}`,
+      });
+    });
+
+    unloadingTrips.forEach((trip) => {
+      const date = normalizeDate(trip.arrival_date);
+      timelineEvents.push({
+        type: "unload",
+        date,
+        label: `Descarga #${trip.sequence}`,
+        description: `${trip.tonnage} t descarregadas para ${trip.destination}`,
+      });
+    });
+
+    processingBatches.forEach((batch) => {
+      const date = normalizeDate(batch.start_date);
+      timelineEvents.push({
+        type: "processing",
+        date,
+        label: `Processamento ${batch.batch_code}`,
+        description: `${batch.tonnage_consumed} t convertidas em ${batch.tonnage_produced} t de ${batch.finished_product_name}`,
+      });
+    });
+
+    outboundShipments.forEach((shipment) => {
+      const date = normalizeDate(shipment.shipping_date);
+      timelineEvents.push({
+        type: "outbound",
+        date,
+        label: `Saída ${shipment.order_code}`,
+        description: `${shipment.tonnage} t enviadas para ${shipment.customer_name}`,
+      });
+    });
+
+    timelineEvents.sort((a, b) => {
+      if (!a.date && !b.date) return 0;
+      if (!a.date) return 1;
+      if (!b.date) return -1;
+      return b.date.getTime() - a.date.getTime();
+    });
+
+    return {
+      metrics: {
+        totalPurchasedTonnage: Number(totalPurchasedTonnage.toFixed(2)),
+        totalUnloadedTonnage: Number(totalUnloadedTonnage.toFixed(2)),
+        inTransitTonnage: Number(inTransitTonnage.toFixed(2)),
+        rawYardInventory: Number(rawYardInventory.toFixed(2)),
+        finishedYardInventory: Number(finishedYardInventory.toFixed(2)),
+        totalOutboundTonnage: Number(totalOutboundTonnage.toFixed(2)),
+        scheduledOutboundTonnage: Number(scheduledOutboundTonnage.toFixed(2)),
+        deliveredOutboundTonnage: Number(deliveredOutboundTonnage.toFixed(2)),
+      },
+      productBreakdown,
+      timelineEvents,
+    };
+  }, [bargeLoads, outboundShipments, processingBatches, unloadingTrips]);
+}
+
+export default useInventoryFlow;

--- a/src/hooks/useInventoryFlow.js
+++ b/src/hooks/useInventoryFlow.js
@@ -1,7 +1,14 @@
 import { useMemo } from "react";
 
 function sumBy(items, selector) {
-  return items.reduce((total, item) => total + (selector(item) || 0), 0);
+  return items.reduce((total, item) => {
+    const value = Number(selector(item));
+    return total + (Number.isFinite(value) ? value : 0);
+  }, 0);
+}
+
+function clampTonnage(value) {
+  return Number(Math.max(value, 0).toFixed(2));
 }
 
 function normalizeDate(value) {
@@ -40,83 +47,93 @@ export function useInventoryFlow({
       (item) => item.tonnage,
     );
 
-    const inTransitTonnage = Math.max(totalPurchasedTonnage - totalUnloadedTonnage, 0);
-    const rawYardInventory = Math.max(totalUnloadedTonnage - totalProcessingConsumption, 0);
-    const finishedYardInventory = Math.max(totalProcessedTonnage - deliveredOutboundTonnage, 0);
+    const inTransitTonnage = clampTonnage(totalPurchasedTonnage - totalUnloadedTonnage);
+    const rawYardInventory = clampTonnage(totalUnloadedTonnage - totalProcessingConsumption);
+    const finishedYardInventory = clampTonnage(totalProcessedTonnage - deliveredOutboundTonnage);
 
     const productBreakdown = [];
     const productMap = new Map();
 
-    bargeLoads.forEach((barge) => {
-      if (!productMap.has(barge.product_id)) {
-        productMap.set(barge.product_id, {
-          product_id: barge.product_id,
-          product_name: barge.product_name,
+    const ensureProduct = ({ id, name }) => {
+      if (id == null) {
+        return null;
+      }
+
+      if (!productMap.has(id)) {
+        productMap.set(id, {
+          product_id: id,
+          product_name: name,
           rawPurchased: 0,
           rawAvailable: 0,
           finishedAvailable: 0,
           committed: 0,
         });
       }
-      const productEntry = productMap.get(barge.product_id);
-      productEntry.rawPurchased += barge.total_tonnage || 0;
+      return productMap.get(id);
+    };
+
+    bargeLoads.forEach((barge) => {
+      const productEntry = ensureProduct({ id: barge.product_id, name: barge.product_name });
+      if (productEntry) {
+        productEntry.rawPurchased += Number(barge.total_tonnage) || 0;
+      }
     });
 
     unloadingTrips.forEach((trip) => {
       const productEntry = productMap.get(trip.product_id);
       if (productEntry) {
-        productEntry.rawAvailable += trip.tonnage || 0;
+        productEntry.rawAvailable += Number(trip.tonnage) || 0;
       }
     });
 
     processingBatches.forEach((batch) => {
       const rawProduct = productMap.get(batch.raw_product_id);
       if (rawProduct) {
-        rawProduct.rawAvailable -= batch.tonnage_consumed || 0;
+        rawProduct.rawAvailable -= Number(batch.tonnage_consumed) || 0;
       }
 
-      if (!productMap.has(batch.finished_product_id)) {
-        productMap.set(batch.finished_product_id, {
-          product_id: batch.finished_product_id,
-          product_name: batch.finished_product_name,
-          rawPurchased: 0,
-          rawAvailable: 0,
-          finishedAvailable: 0,
-          committed: 0,
-        });
+      const finishedProduct = ensureProduct({
+        id: batch.finished_product_id,
+        name: batch.finished_product_name,
+      });
+      if (finishedProduct) {
+        finishedProduct.finishedAvailable += Number(batch.tonnage_produced) || 0;
       }
-
-      const finishedProduct = productMap.get(batch.finished_product_id);
-      finishedProduct.finishedAvailable += batch.tonnage_produced || 0;
     });
 
+    const outboundStatusLabels = {
+      scheduled: "Agendado",
+      completed: "Concluído",
+      in_transit: "Em trânsito",
+      cancelled: "Cancelado",
+    };
+
     outboundShipments.forEach((shipment) => {
-      if (!productMap.has(shipment.product_id)) {
-        productMap.set(shipment.product_id, {
-          product_id: shipment.product_id,
-          product_name: shipment.product_name,
-          rawPurchased: 0,
-          rawAvailable: 0,
-          finishedAvailable: 0,
-          committed: 0,
-        });
+      const productEntry = ensureProduct({ id: shipment.product_id, name: shipment.product_name });
+      if (!productEntry) {
+        return;
       }
 
-      const productEntry = productMap.get(shipment.product_id);
       if (shipment.status === "completed") {
-        productEntry.finishedAvailable -= shipment.tonnage || 0;
+        productEntry.finishedAvailable -= Number(shipment.tonnage) || 0;
       } else if (shipment.status === "scheduled") {
-        productEntry.committed += shipment.tonnage || 0;
+        productEntry.committed += Number(shipment.tonnage) || 0;
       }
     });
 
     productMap.forEach((value) => {
+      const rawAvailable = clampTonnage(value.rawAvailable);
+      const rawPurchased = clampTonnage(value.rawPurchased);
+      const finishedAvailable = clampTonnage(value.finishedAvailable);
+      const committed = clampTonnage(value.committed);
+      const netFinished = clampTonnage(finishedAvailable - committed);
       productBreakdown.push({
         ...value,
-        rawAvailable: Number(value.rawAvailable.toFixed(2)),
-        rawPurchased: Number(value.rawPurchased.toFixed(2)),
-        finishedAvailable: Number(value.finishedAvailable.toFixed(2)),
-        committed: Number(value.committed.toFixed(2)),
+        rawAvailable,
+        rawPurchased,
+        finishedAvailable,
+        committed,
+        netFinishedAvailable: netFinished,
       });
     });
 
@@ -156,11 +173,12 @@ export function useInventoryFlow({
 
     outboundShipments.forEach((shipment) => {
       const date = normalizeDate(shipment.shipping_date);
+      const statusLabel = outboundStatusLabels[shipment.status] || shipment.status || "Status desconhecido";
       timelineEvents.push({
         type: "outbound",
         date,
         label: `Saída ${shipment.order_code}`,
-        description: `${shipment.tonnage} t enviadas para ${shipment.customer_name}`,
+        description: `${shipment.tonnage} t enviadas para ${shipment.customer_name} (${statusLabel})`,
       });
     });
 
@@ -173,14 +191,14 @@ export function useInventoryFlow({
 
     return {
       metrics: {
-        totalPurchasedTonnage: Number(totalPurchasedTonnage.toFixed(2)),
-        totalUnloadedTonnage: Number(totalUnloadedTonnage.toFixed(2)),
-        inTransitTonnage: Number(inTransitTonnage.toFixed(2)),
-        rawYardInventory: Number(rawYardInventory.toFixed(2)),
-        finishedYardInventory: Number(finishedYardInventory.toFixed(2)),
-        totalOutboundTonnage: Number(totalOutboundTonnage.toFixed(2)),
-        scheduledOutboundTonnage: Number(scheduledOutboundTonnage.toFixed(2)),
-        deliveredOutboundTonnage: Number(deliveredOutboundTonnage.toFixed(2)),
+        totalPurchasedTonnage: clampTonnage(totalPurchasedTonnage),
+        totalUnloadedTonnage: clampTonnage(totalUnloadedTonnage),
+        inTransitTonnage,
+        rawYardInventory,
+        finishedYardInventory,
+        totalOutboundTonnage: clampTonnage(totalOutboundTonnage),
+        scheduledOutboundTonnage: clampTonnage(scheduledOutboundTonnage),
+        deliveredOutboundTonnage: clampTonnage(deliveredOutboundTonnage),
       },
       productBreakdown,
       timelineEvents,

--- a/src/pages/Clientes.jsx
+++ b/src/pages/Clientes.jsx
@@ -10,6 +10,8 @@ import CustomerList from '../components/customers/CustomerList';
 import CustomerSearchModal from '../components/customers/CustomerSearchModal';
 import { useCompany } from '../components/common/CompanyContext';
 import { supabase } from '../lib/supabaseClient';
+import importService from '@/services/importService';
+import { parseContactsCSV } from '@/utils/importParsers';
 
 export default function ClientesPage() {
     const { currentCompany } = useCompany();
@@ -109,9 +111,64 @@ export default function ClientesPage() {
     };
 
     const handleFileImport = async (event) => {
-        alert("Funcionalidade de importação temporariamente desabilitada. Use o formulário para adicionar clientes individualmente.");
-        if(fileInputRef.current) {
-            fileInputRef.current.value = "";
+        const file = event.target.files?.[0];
+
+        if (!file) {
+            return;
+        }
+
+        if (!currentCompany) {
+            alert('Erro: selecione uma filial antes de importar clientes.');
+            if (fileInputRef.current) {
+                fileInputRef.current.value = '';
+            }
+            return;
+        }
+
+        setIsImporting(true);
+
+        try {
+            const text = await file.text();
+            const parsedCustomers = parseContactsCSV(text);
+
+            if (parsedCustomers.length === 0) {
+                alert('Nenhum cliente válido encontrado no arquivo selecionado.');
+                return;
+            }
+
+            const validationErrors = importService.validateData(parsedCustomers, 'contacts');
+
+            if (validationErrors.length > 0) {
+                const formatted = validationErrors
+                    .slice(0, 5)
+                    .map(error => `Linha ${error.row}: ${error.errors.join(', ')}`)
+                    .join('\n');
+
+                const suffix = validationErrors.length > 5 ? '\n... (corrija os demais registros e tente novamente)' : '';
+                alert(`Erros de validação encontrados:\n${formatted}${suffix}`);
+                return;
+            }
+
+            const results = await importService.importContacts(parsedCustomers, currentCompany.id);
+
+            await loadData();
+
+            const summary = [
+                `Clientes importados: ${results.success}/${results.total}`,
+                results.errors ? `Registros com erro: ${results.errors}` : null
+            ]
+                .filter(Boolean)
+                .join('\n');
+
+            alert(`Importação concluída!\n${summary}`);
+        } catch (error) {
+            console.error('Erro ao importar clientes:', error);
+            alert(`Falha ao importar clientes: ${error.message}`);
+        } finally {
+            setIsImporting(false);
+            if (fileInputRef.current) {
+                fileInputRef.current.value = '';
+            }
         }
     };
 

--- a/src/pages/Clientes.jsx
+++ b/src/pages/Clientes.jsx
@@ -12,6 +12,160 @@ import { useCompany } from '../components/common/CompanyContext';
 import { supabase } from '../lib/supabaseClient';
 import importService from '@/services/importService';
 import { parseContactsCSV } from '@/utils/importParsers';
+import { mapClientType, cleanDocument, formatPhone } from '@/data/clientesTemplate';
+
+const CONTACT_IMPORT_BATCH_SIZE = 50;
+const INACTIVE_FLAG_VALUES = new Set(['0', 'false', 'nao', 'não', 'inativo', 'inativado', 'desativado', 'desativo']);
+
+const toNullableString = (value) => {
+    if (value === undefined || value === null) {
+        return null;
+    }
+
+    const text = value.toString().trim();
+    return text.length > 0 ? text : null;
+};
+
+const pickFirstFilled = (...values) => {
+    for (const value of values) {
+        const parsed = toNullableString(value);
+        if (parsed) {
+            return parsed;
+        }
+    }
+
+    return null;
+};
+
+const resolveActiveFlag = (value) => {
+    if (value === undefined || value === null || value === '') {
+        return true;
+    }
+
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    const normalized = value.toString().trim().toLowerCase();
+    return !INACTIVE_FLAG_VALUES.has(normalized);
+};
+
+const resolveContactType = (row) => {
+    const directType = toNullableString(row?.tipo);
+
+    if (directType) {
+        const normalized = directType.toLowerCase();
+
+        if (['fornecedor', 'supplier'].includes(normalized)) {
+            return 'fornecedor';
+        }
+
+        if (['funcionario', 'funcionário', 'colaborador'].includes(normalized)) {
+            return 'funcionario';
+        }
+
+        if (['outro', 'outros', 'outros clientes'].includes(normalized)) {
+            return 'outro';
+        }
+
+        if (['cliente', 'client'].includes(normalized)) {
+            return 'cliente';
+        }
+    }
+
+    return mapClientType(row?.tipo_lista_precos, row?.cnpj, row?.cpf) || 'cliente';
+};
+
+const resolveDocumentValue = (row) => {
+    const document = pickFirstFilled(row?.documento, row?.cnpj, row?.cpf);
+
+    if (!document) {
+        return null;
+    }
+
+    const cleaned = cleanDocument(document);
+    return cleaned || null;
+};
+
+const resolvePhoneValue = (row) => {
+    const phone = pickFirstFilled(row?.telefone, row?.celular);
+
+    if (!phone) {
+        return null;
+    }
+
+    return formatPhone(phone);
+};
+
+const resolveAddressValue = (row) => {
+    const composed = [row?.endereco, row?.numero, row?.complemento]
+        .map((part) => toNullableString(part))
+        .filter(Boolean);
+
+    if (composed.length > 0) {
+        return composed.join(', ');
+    }
+
+    return pickFirstFilled(row?.address, row?.logradouro);
+};
+
+const mapRowToContactPayload = (row, empresaId, timestamp) => {
+    const name =
+        pickFirstFilled(
+            row?.nome,
+            row?.nome_razao_social,
+            row?.apelido_nome_fantasia,
+            row?.cliente,
+            row?.empresa
+        ) || 'Cliente sem nome';
+
+    const address = resolveAddressValue(row);
+
+    return {
+        name,
+        email: toNullableString(row?.email),
+        phone: resolvePhoneValue(row),
+        document: resolveDocumentValue(row),
+        type: resolveContactType(row),
+        address: address ?? null,
+        city: toNullableString(row?.cidade),
+        state: toNullableString(row?.estado) || toNullableString(row?.uf),
+        zip_code: toNullableString(row?.cep),
+        active: resolveActiveFlag(row?.ativo ?? row?.status),
+        empresa_id: empresaId,
+        created_at: timestamp,
+        updated_at: timestamp,
+    };
+};
+
+const fallbackImportContacts = async (rows, empresaId) => {
+    const timestamp = new Date().toISOString();
+    const results = {
+        total: rows.length,
+        success: 0,
+        errors: 0,
+    };
+
+    for (let index = 0; index < rows.length; index += CONTACT_IMPORT_BATCH_SIZE) {
+        const batch = rows.slice(index, index + CONTACT_IMPORT_BATCH_SIZE);
+        const payload = batch.map((row) => mapRowToContactPayload(row, empresaId, timestamp));
+
+        const { data, error } = await supabase
+            .from('contacts')
+            .insert(payload)
+            .select();
+
+        if (error) {
+            throw new Error(`Erro no lote ${Math.floor(index / CONTACT_IMPORT_BATCH_SIZE) + 1}: ${error.message}`);
+        }
+
+        results.success += data?.length || 0;
+    }
+
+    results.errors = Math.max(results.total - results.success, 0);
+
+    return results;
+};
 
 export default function ClientesPage() {
     const { currentCompany } = useCompany();
@@ -149,13 +303,34 @@ export default function ClientesPage() {
                 return;
             }
 
-            const results = await importService.importContacts(parsedCustomers, currentCompany.id);
+            let results;
+            let usedFallback = false;
+
+            try {
+                results = await importService.importContacts(parsedCustomers, currentCompany.id);
+            } catch (serviceError) {
+                const message = serviceError?.message?.toLowerCase?.() || '';
+                const serviceDisabled = message.includes('desabil') || message.includes('disabled');
+
+                if (!serviceDisabled) {
+                    throw serviceError;
+                }
+
+                console.warn('Serviço de importação indisponível. Aplicando fallback direto no Supabase.', serviceError);
+                usedFallback = true;
+                results = await fallbackImportContacts(parsedCustomers, currentCompany.id);
+            }
 
             await loadData();
 
+            const total = results?.total ?? parsedCustomers.length;
+            const success = results?.success ?? 0;
+            const errorsCount = results?.errors ?? Math.max(total - success, 0);
+
             const summary = [
-                `Clientes importados: ${results.success}/${results.total}`,
-                results.errors ? `Registros com erro: ${results.errors}` : null
+                `Clientes importados: ${success}/${total}`,
+                errorsCount ? `Registros com erro: ${errorsCount}` : null,
+                usedFallback ? 'Importação realizada no modo de compatibilidade.' : null
             ]
                 .filter(Boolean)
                 .join('\n');

--- a/src/pages/Warehouse.jsx
+++ b/src/pages/Warehouse.jsx
@@ -10,30 +10,95 @@ import StockEntryForm from "../components/warehouse/StockEntryForm";
 import StockList from "../components/warehouse/StockList";
 import StockFilters from "../components/warehouse/StockFilters";
 import StockStats from "../components/warehouse/StockStats";
+import StockFlowDashboard from "../components/warehouse/StockFlowDashboard";
 import { useCompany } from "../components/common/CompanyContext";
+import useInventoryFlow from "../hooks/useInventoryFlow";
 
 export default function Warehouse() {
   const { currentCompany } = useCompany();
 
   // Dados de exemplo (mock data) para substituir as chamadas de API
   const mockProducts = [
-    { id: 1, name: 'Cimento Portland', code: 'PROD000001', category: 'Cimento', cost_price: 25.50 },
-    { id: 2, name: 'Areia Fina', code: 'PROD000002', category: 'Agregados', cost_price: 15.00 },
-    { id: 3, name: 'Brita 1', code: 'PROD000003', category: 'Agregados', cost_price: 18.00 },
-    { id: 4, name: 'Cal Hidratada', code: 'PROD000004', category: 'Cal', cost_price: 12.50 },
-    { id: 5, name: 'Argila', code: 'PROD000005', category: 'Agregados', cost_price: 8.00 }
+    { id: 101, name: 'Calcário In Natura', code: 'CALC-RAW-001', category: 'Matéria-Prima', unit_of_measure: 'TON', cost_price: 110.00 },
+    { id: 201, name: 'Calcário Britado 0-32', code: 'CALC-PRO-201', category: 'Produto Acabado', unit_of_measure: 'TON', cost_price: 185.00 },
+    { id: 202, name: 'Calcário Micronizado', code: 'CALC-PRO-202', category: 'Produto Acabado', unit_of_measure: 'TON', cost_price: 260.00 },
+    { id: 301, name: 'Resíduo Calcário Fino', code: 'CALC-BY-301', category: 'Subproduto', unit_of_measure: 'TON', cost_price: 0.00 },
   ];
 
   const mockStockEntries = [
-    { id: 1, reference: 'ENT000001', product_id: 1, quantity_received: 200, quantity_available: 150, unit_cost: 25.50, status: 'ativo', origem_entrada: 'compra', setor: 'almoxarifado', entry_date: '2024-01-15T10:00:00Z', notes: 'Entrada de cimento Portland' },
-    { id: 2, reference: 'ENT000002', product_id: 2, quantity_received: 350, quantity_available: 300, unit_cost: 15.00, status: 'ativo', origem_entrada: 'compra', setor: 'almoxarifado', entry_date: '2024-01-14T14:30:00Z', notes: 'Entrada de areia fina' },
-    { id: 3, reference: 'ENT000003', product_id: 3, quantity_received: 150, quantity_available: 120, unit_cost: 18.00, status: 'ativo', origem_entrada: 'compra', setor: 'almoxarifado', entry_date: '2024-01-13T09:15:00Z', notes: 'Entrada de brita 1' },
-    { id: 4, reference: 'ENT000004', product_id: 4, quantity_received: 60, quantity_available: 45, unit_cost: 12.50, status: 'ativo', origem_entrada: 'compra', setor: 'almoxarifado', entry_date: '2024-01-12T16:45:00Z', notes: 'Entrada de cal hidratada' },
-    { id: 5, reference: 'ENT000005', product_id: 5, quantity_received: 250, quantity_available: 200, unit_cost: 8.00, status: 'ativo', origem_entrada: 'compra', setor: 'almoxarifado', entry_date: '2024-01-11T11:20:00Z', notes: 'Entrada de argila' }
+    {
+      id: 1,
+      reference: 'ENT000601',
+      product_id: 101,
+      quantity_received: 500,
+      quantity_available: 360,
+      unit_cost: 110.00,
+      status: 'ativo',
+      origem_entrada: 'compra',
+      setor: 'almoxarifado',
+      entry_date: '2024-01-06T10:00:00Z',
+      notes: '1ª descarga da balsa BL-2401',
+    },
+    {
+      id: 2,
+      reference: 'ENT000602',
+      product_id: 101,
+      quantity_received: 420,
+      quantity_available: 390,
+      unit_cost: 110.00,
+      status: 'ativo',
+      origem_entrada: 'compra',
+      setor: 'almoxarifado',
+      entry_date: '2024-01-08T15:30:00Z',
+      notes: '2ª descarga da balsa BL-2401',
+    },
+    {
+      id: 3,
+      reference: 'ENT000701',
+      product_id: 101,
+      quantity_received: 410,
+      quantity_available: 410,
+      unit_cost: 112.00,
+      status: 'ativo',
+      origem_entrada: 'compra',
+      setor: 'almoxarifado',
+      entry_date: '2024-02-14T09:45:00Z',
+      notes: 'Descarga parcial da balsa BL-2402',
+    },
+    {
+      id: 4,
+      reference: 'ENT-PROC-2401',
+      product_id: 201,
+      quantity_received: 225,
+      quantity_available: 180,
+      unit_cost: 0,
+      status: 'ativo',
+      origem_entrada: 'processamento',
+      setor: 'producao',
+      entry_date: '2024-01-12T11:00:00Z',
+      notes: 'Lote produzido do processo PROC-2401-01',
+    },
+    {
+      id: 5,
+      reference: 'ENT-PROC-2402',
+      product_id: 202,
+      quantity_received: 162,
+      quantity_available: 162,
+      unit_cost: 0,
+      status: 'ativo',
+      origem_entrada: 'processamento',
+      setor: 'producao',
+      entry_date: '2024-02-19T10:00:00Z',
+      notes: 'Lote produzido do processo PROC-2402-01',
+    },
   ];
 
   const [stockEntries, setStockEntries] = useState([]);
   const [products, setProducts] = useState([]);
+  const [bargeLoads, setBargeLoads] = useState([]);
+  const [unloadingTrips, setUnloadingTrips] = useState([]);
+  const [processingBatches, setProcessingBatches] = useState([]);
+  const [outboundShipments, setOutboundShipments] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [editingEntry, setEditingEntry] = useState(null);
@@ -50,12 +115,125 @@ export default function Warehouse() {
       // Carregar dados de exemplo
       setStockEntries(mockStockEntries);
       setProducts(mockProducts);
+
+      const mockBargeLoads = [
+        {
+          id: 1,
+          barge_code: "BL-2401",
+          supplier: "Mineração Tapajós",
+          product_id: 101,
+          product_name: "Calcário In Natura",
+          purchase_date: "2024-01-02T08:00:00Z",
+          total_tonnage: 1000,
+        },
+        {
+          id: 2,
+          barge_code: "BL-2402",
+          supplier: "Pedreira São Jorge",
+          product_id: 101,
+          product_name: "Calcário In Natura",
+          purchase_date: "2024-02-10T10:00:00Z",
+          total_tonnage: 800,
+        },
+      ];
+
+      const mockUnloadingTrips = [
+        {
+          id: 11,
+          barge_id: 1,
+          sequence: 1,
+          product_id: 101,
+          arrival_date: "2024-01-05T14:30:00Z",
+          tonnage: 320,
+          destination: "Pátio Santarém",
+        },
+        {
+          id: 12,
+          barge_id: 1,
+          sequence: 2,
+          product_id: 101,
+          arrival_date: "2024-01-07T16:00:00Z",
+          tonnage: 340,
+          destination: "Pátio Santarém",
+        },
+        {
+          id: 21,
+          barge_id: 2,
+          sequence: 1,
+          product_id: 101,
+          arrival_date: "2024-02-14T09:45:00Z",
+          tonnage: 410,
+          destination: "Pátio Santarém",
+        },
+      ];
+
+      const mockProcessingBatches = [
+        {
+          id: 100,
+          batch_code: "PROC-2401-01",
+          start_date: "2024-01-09T08:00:00Z",
+          raw_product_id: 101,
+          finished_product_id: 201,
+          finished_product_name: "Calcário Britado 0-32",
+          tonnage_consumed: 250,
+          tonnage_produced: 225,
+        },
+        {
+          id: 101,
+          batch_code: "PROC-2402-01",
+          start_date: "2024-02-18T07:30:00Z",
+          raw_product_id: 101,
+          finished_product_id: 202,
+          finished_product_name: "Calcário Micronizado",
+          tonnage_consumed: 180,
+          tonnage_produced: 162,
+        },
+      ];
+
+      const mockOutboundShipments = [
+        {
+          id: 301,
+          order_code: "PED-5001",
+          product_id: 201,
+          product_name: "Calcário Britado 0-32",
+          customer_name: "Agro Amazônia",
+          shipping_date: "2024-01-20T12:00:00Z",
+          tonnage: 120,
+          status: "completed",
+        },
+        {
+          id: 302,
+          order_code: "PED-5002",
+          product_id: 202,
+          product_name: "Calcário Micronizado",
+          customer_name: "Cooperativa Vale Verde",
+          shipping_date: "2024-02-22T08:30:00Z",
+          tonnage: 90,
+          status: "scheduled",
+        },
+      ];
+
+      setBargeLoads(mockBargeLoads);
+      setUnloadingTrips(mockUnloadingTrips);
+      setProcessingBatches(mockProcessingBatches);
+      setOutboundShipments(mockOutboundShipments);
     } else {
       // Limpar dados se nenhuma filial estiver selecionada
       setStockEntries([]);
       setProducts([]);
+      setBargeLoads([]);
+      setUnloadingTrips([]);
+      setProcessingBatches([]);
+      setOutboundShipments([]);
     }
   }, [currentCompany]);
+
+  const { metrics, productBreakdown, timelineEvents } = useInventoryFlow({
+    bargeLoads,
+    unloadingTrips,
+    processingBatches,
+    outboundShipments,
+  });
 
   const handleSubmit = async (entryData) => {
     try {
@@ -173,6 +351,12 @@ export default function Warehouse() {
             Registrar Nova Entrada no Estoque
           </Button>
         </div>
+
+        <StockFlowDashboard
+          metrics={metrics}
+          productBreakdown={productBreakdown}
+          timelineEvents={timelineEvents}
+        />
 
         <StockStats stockEntries={stockEntries} products={products} isLoading={isLoading} />
         

--- a/src/pages/Warehouse.jsx
+++ b/src/pages/Warehouse.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Plus, Search, Building2, Package, TrendingUp } from "lucide-react";
+import { Plus, Search } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 
 import StockEntryForm from "../components/warehouse/StockEntryForm";
@@ -14,84 +14,115 @@ import StockFlowDashboard from "../components/warehouse/StockFlowDashboard";
 import { useCompany } from "../components/common/CompanyContext";
 import useInventoryFlow from "../hooks/useInventoryFlow";
 
+const CALCARIO_PRODUCTS = [
+  {
+    id: 101,
+    name: "Calcário In Natura",
+    code: "CALC-RAW-001",
+    category: "Matéria-Prima",
+    unit_of_measure: "TON",
+    cost_price: 110,
+  },
+  {
+    id: 201,
+    name: "Calcário Britado 0-32",
+    code: "CALC-PRO-201",
+    category: "Produto Acabado",
+    unit_of_measure: "TON",
+    cost_price: 185,
+  },
+  {
+    id: 202,
+    name: "Calcário Micronizado",
+    code: "CALC-PRO-202",
+    category: "Produto Acabado",
+    unit_of_measure: "TON",
+    cost_price: 260,
+  },
+  {
+    id: 301,
+    name: "Resíduo Calcário Fino",
+    code: "CALC-BY-301",
+    category: "Subproduto",
+    unit_of_measure: "TON",
+    cost_price: 0,
+  },
+];
+
+const CALCARIO_STOCK_ENTRIES = [
+  {
+    id: 1,
+    reference: "ENT000601",
+    product_id: 101,
+    quantity_received: 500,
+    quantity_available: 360,
+    unit_cost: 110,
+    status: "ativo",
+    origem_entrada: "compra",
+    setor: "almoxarifado",
+    entry_date: "2024-01-06T10:00:00Z",
+    notes: "1ª descarga da balsa BL-2401",
+  },
+  {
+    id: 2,
+    reference: "ENT000602",
+    product_id: 101,
+    quantity_received: 420,
+    quantity_available: 390,
+    unit_cost: 110,
+    status: "ativo",
+    origem_entrada: "compra",
+    setor: "almoxarifado",
+    entry_date: "2024-01-08T15:30:00Z",
+    notes: "2ª descarga da balsa BL-2401",
+  },
+  {
+    id: 3,
+    reference: "ENT000701",
+    product_id: 101,
+    quantity_received: 410,
+    quantity_available: 410,
+    unit_cost: 112,
+    status: "ativo",
+    origem_entrada: "compra",
+    setor: "almoxarifado",
+    entry_date: "2024-02-14T09:45:00Z",
+    notes: "Descarga parcial da balsa BL-2402",
+  },
+  {
+    id: 4,
+    reference: "ENT-PROC-2401",
+    product_id: 201,
+    quantity_received: 225,
+    quantity_available: 180,
+    unit_cost: 0,
+    status: "ativo",
+    origem_entrada: "processamento",
+    setor: "producao",
+    entry_date: "2024-01-12T11:00:00Z",
+    notes: "Lote produzido do processo PROC-2401-01",
+  },
+  {
+    id: 5,
+    reference: "ENT-PROC-2402",
+    product_id: 202,
+    quantity_received: 162,
+    quantity_available: 162,
+    unit_cost: 0,
+    status: "ativo",
+    origem_entrada: "processamento",
+    setor: "producao",
+    entry_date: "2024-02-19T10:00:00Z",
+    notes: "Lote produzido do processo PROC-2402-01",
+  },
+];
+
 export default function Warehouse() {
   const { currentCompany } = useCompany();
 
   // Dados de exemplo (mock data) para substituir as chamadas de API
-  const mockProducts = [
-    { id: 101, name: 'Calcário In Natura', code: 'CALC-RAW-001', category: 'Matéria-Prima', unit_of_measure: 'TON', cost_price: 110.00 },
-    { id: 201, name: 'Calcário Britado 0-32', code: 'CALC-PRO-201', category: 'Produto Acabado', unit_of_measure: 'TON', cost_price: 185.00 },
-    { id: 202, name: 'Calcário Micronizado', code: 'CALC-PRO-202', category: 'Produto Acabado', unit_of_measure: 'TON', cost_price: 260.00 },
-    { id: 301, name: 'Resíduo Calcário Fino', code: 'CALC-BY-301', category: 'Subproduto', unit_of_measure: 'TON', cost_price: 0.00 },
-  ];
-
-  const mockStockEntries = [
-    {
-      id: 1,
-      reference: 'ENT000601',
-      product_id: 101,
-      quantity_received: 500,
-      quantity_available: 360,
-      unit_cost: 110.00,
-      status: 'ativo',
-      origem_entrada: 'compra',
-      setor: 'almoxarifado',
-      entry_date: '2024-01-06T10:00:00Z',
-      notes: '1ª descarga da balsa BL-2401',
-    },
-    {
-      id: 2,
-      reference: 'ENT000602',
-      product_id: 101,
-      quantity_received: 420,
-      quantity_available: 390,
-      unit_cost: 110.00,
-      status: 'ativo',
-      origem_entrada: 'compra',
-      setor: 'almoxarifado',
-      entry_date: '2024-01-08T15:30:00Z',
-      notes: '2ª descarga da balsa BL-2401',
-    },
-    {
-      id: 3,
-      reference: 'ENT000701',
-      product_id: 101,
-      quantity_received: 410,
-      quantity_available: 410,
-      unit_cost: 112.00,
-      status: 'ativo',
-      origem_entrada: 'compra',
-      setor: 'almoxarifado',
-      entry_date: '2024-02-14T09:45:00Z',
-      notes: 'Descarga parcial da balsa BL-2402',
-    },
-    {
-      id: 4,
-      reference: 'ENT-PROC-2401',
-      product_id: 201,
-      quantity_received: 225,
-      quantity_available: 180,
-      unit_cost: 0,
-      status: 'ativo',
-      origem_entrada: 'processamento',
-      setor: 'producao',
-      entry_date: '2024-01-12T11:00:00Z',
-      notes: 'Lote produzido do processo PROC-2401-01',
-    },
-    {
-      id: 5,
-      reference: 'ENT-PROC-2402',
-      product_id: 202,
-      quantity_received: 162,
-      quantity_available: 162,
-      unit_cost: 0,
-      status: 'ativo',
-      origem_entrada: 'processamento',
-      setor: 'producao',
-      entry_date: '2024-02-19T10:00:00Z',
-      notes: 'Lote produzido do processo PROC-2402-01',
-    },
-  ];
+  const mockProducts = CALCARIO_PRODUCTS;
+  const mockStockEntries = CALCARIO_STOCK_ENTRIES;
 
   const [stockEntries, setStockEntries] = useState([]);
   const [products, setProducts] = useState([]);
@@ -99,21 +130,20 @@ export default function Warehouse() {
   const [unloadingTrips, setUnloadingTrips] = useState([]);
   const [processingBatches, setProcessingBatches] = useState([]);
   const [outboundShipments, setOutboundShipments] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const isLoading = false;
   const [showForm, setShowForm] = useState(false);
   const [editingEntry, setEditingEntry] = useState(null);
-  const [searchTerm, setSearchTerm] = useState('');
+  const [searchTerm, setSearchTerm] = useState("");
   const [filters, setFilters] = useState({
-    setor: 'all',
-    origem_entrada: 'all',
-    status: 'ativo',
-    categoria: 'all'
+    setor: "all",
+    origem_entrada: "all",
+    status: "ativo",
+    categoria: "all",
   });
 
   useEffect(() => {
     if (currentCompany) {
       // Carregar dados de exemplo
-      setStockEntries(mockStockEntries);
       setProducts(mockProducts);
 
       const mockBargeLoads = [
@@ -213,6 +243,13 @@ export default function Warehouse() {
         },
       ];
 
+      const stockEntriesWithCompany = mockStockEntries.map((entry) => ({
+        ...entry,
+        company_id: currentCompany.id,
+        company_name: currentCompany.name,
+      }));
+
+      setStockEntries(stockEntriesWithCompany);
       setBargeLoads(mockBargeLoads);
       setUnloadingTrips(mockUnloadingTrips);
       setProcessingBatches(mockProcessingBatches);
@@ -237,55 +274,56 @@ export default function Warehouse() {
 
   const handleSubmit = async (entryData) => {
     try {
-      console.log('Dados recebidos para salvar:', entryData);
-      
+      console.log("Dados recebidos para salvar:", entryData);
+
       if (!entryData.product_id) {
         alert("Erro: Produto não selecionado corretamente.");
         return;
       }
 
       if (!currentCompany || !currentCompany.id) {
-          alert("Erro: Empresa não selecionada. Não foi possível salvar a entrada.");
-          return;
+        alert("Erro: Empresa não selecionada. Não foi possível salvar a entrada.");
+        return;
       }
 
+      const setorFromEntry = entryData.setor || currentCompany?.code?.toLowerCase() || "almoxarifado";
       const dataToSave = {
-          ...entryData,
-          company_id: currentCompany.id,
-          company_name: currentCompany.name,
-          setor: currentCompany.code.toLowerCase(),
+        ...entryData,
+        company_id: currentCompany.id,
+        company_name: currentCompany.name,
+        setor: setorFromEntry,
       };
-      
+
       if (editingEntry) {
         // Simular atualização
-        const updatedEntries = stockEntries.map(entry => 
-          entry.id === editingEntry.id 
+        const updatedEntries = stockEntries.map((entry) =>
+          entry.id === editingEntry.id
             ? { ...entry, ...dataToSave, quantity_available: dataToSave.quantity_received }
-            : entry
+            : entry,
         );
         setStockEntries(updatedEntries);
-        alert('Entrada de estoque atualizada com sucesso!');
+        alert("Entrada de estoque atualizada com sucesso!");
       } else {
         // Simular criação
-        const newId = Math.max(...stockEntries.map(e => e.id)) + 1;
+        const nextId = stockEntries.length > 0 ? Math.max(...stockEntries.map((e) => e.id)) + 1 : 1;
         const newRef = `ENT${String(Date.now()).slice(-6)}`;
         const newEntry = {
-          id: newId,
+          id: nextId,
           ...dataToSave,
           reference: newRef,
-          status: 'ativo',
+          status: "ativo",
           quantity_available: dataToSave.quantity_received,
-          entry_date: new Date().toISOString()
+          entry_date: new Date().toISOString(),
         };
         setStockEntries([...stockEntries, newEntry]);
-        alert('Entrada de estoque criada com sucesso!');
+        alert("Entrada de estoque criada com sucesso!");
       }
-      
+
       setShowForm(false);
       setEditingEntry(null);
     } catch (error) {
-      console.error('Erro detalhado ao salvar entrada de estoque:', error);
-      alert(`Erro ao salvar entrada de estoque: ${error.message || 'Erro desconhecido'}`);
+      console.error("Erro detalhado ao salvar entrada de estoque:", error);
+      alert(`Erro ao salvar entrada de estoque: ${error.message || "Erro desconhecido"}`);
     }
   };
 
@@ -295,18 +333,22 @@ export default function Warehouse() {
   };
 
   const handleDelete = async (entry) => {
-    if (confirm(`Tem certeza que deseja desativar a entrada "${entry.reference}"?\n\nEsta ação irá:\n- Alterar o status para "consumido"\n- Zerar a quantidade disponível\n- Manter o histórico para auditoria\n\nEsta ação NÃO pode ser desfeita!`)) {
+    if (
+      confirm(
+        `Tem certeza que deseja desativar a entrada "${entry.reference}"?\n\nEsta ação irá:\n- Alterar o status para "consumido"\n- Zerar a quantidade disponível\n- Manter o histórico para auditoria\n\nEsta ação NÃO pode ser desfeita!`,
+      )
+    ) {
       try {
         // Simular desativação
-        const updatedEntries = stockEntries.map(e => 
-          e.id === entry.id 
-            ? { ...e, status: 'consumido', quantity_available: 0 }
-            : e
+        const updatedEntries = stockEntries.map((e) =>
+          e.id === entry.id
+            ? { ...e, status: "consumido", quantity_available: 0 }
+            : e,
         );
         setStockEntries(updatedEntries);
         alert(`Entrada "${entry.reference}" foi desativada com sucesso.`);
       } catch (error) {
-        console.error('Erro ao desativar entrada:', error);
+        console.error("Erro ao desativar entrada:", error);
         alert(`Erro ao desativar entrada: ${error.message}`);
       }
     }
@@ -314,29 +356,31 @@ export default function Warehouse() {
 
   const filteredEntries = useMemo(() => {
     // O filtro por filial já é feito em loadData, então a lista `stockEntries` já está correta.
-    return stockEntries.filter(entry => {
+    return stockEntries.filter((entry) => {
       // This check is technically redundant if loadData is filtering correctly,
       // but keeping it here for an extra layer of safety to ensure UI consistency if data somehow slips through.
       if (currentCompany && entry.company_id !== currentCompany.id) {
-          return false;
+        return false;
       }
 
-      const product = products.find(p => p.id === entry.product_id);
-      
-      const searchMatch = searchTerm === '' || 
-        entry.reference.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        (product && product.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
-        (product && product.code.toLowerCase().includes(searchTerm.toLowerCase())) ||
-        (entry.notes && entry.notes.toLowerCase().includes(searchTerm.toLowerCase())); // Added entry.notes to search criteria
-      
-      const setorMatch = filters.setor === 'all' || entry.setor === filters.setor;
-      const origemMatch = filters.origem_entrada === 'all' || entry.origem_entrada === filters.origem_entrada;
-      const statusMatch = filters.status === 'all' || entry.status === filters.status;
-      const categoryMatch = filters.categoria === 'all' || (product && product.category === filters.categoria);
+      const product = products.find((p) => p.id === entry.product_id);
+
+      const normalizedSearch = searchTerm.trim().toLowerCase();
+      const searchMatch =
+        normalizedSearch === "" ||
+        entry.reference.toLowerCase().includes(normalizedSearch) ||
+        (product && product.name.toLowerCase().includes(normalizedSearch)) ||
+        (product && product.code.toLowerCase().includes(normalizedSearch)) ||
+        (entry.notes && entry.notes.toLowerCase().includes(normalizedSearch)); // Added entry.notes to search criteria
+
+      const setorMatch = filters.setor === "all" || entry.setor === filters.setor;
+      const origemMatch = filters.origem_entrada === "all" || entry.origem_entrada === filters.origem_entrada;
+      const statusMatch = filters.status === "all" || entry.status === filters.status;
+      const categoryMatch = filters.categoria === "all" || (product && product.category === filters.categoria);
 
       return searchMatch && setorMatch && origemMatch && statusMatch && categoryMatch;
     });
-  }, [stockEntries, products, searchTerm, filters]); // Removido currentCompany pois a fonte já é filtrada
+  }, [stockEntries, products, searchTerm, filters, currentCompany]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -41,7 +41,7 @@ import Companies from './Companies';
 import VendaDetalhes from './VendaDetalhes';
 import ContasFinanceiras from './ContasFinanceiras';
 import BackupManager from './BackupManager';
-import { BrowserRouter as Router, Route, Routes, useLocation, matchPath } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 
 const DEFAULT_PAGE_NAME = 'Dashboard';
 
@@ -227,12 +227,46 @@ const PROTECTED_PAGE_CONFIGS = [
   },
 ];
 
-const PROTECTED_LAYOUT_ROUTES = PROTECTED_PAGE_CONFIGS.flatMap(({ paths, ...config }) =>
-  paths.map((path) => ({
-    path,
-    ...config,
-  }))
-);
+function normalizePattern(pathPattern) {
+  if (pathPattern === '/') {
+    return '/';
+  }
+
+  const trimmedPattern = pathPattern.endsWith('/') ? pathPattern.replace(/\/+$/, '') : pathPattern;
+
+  return trimmedPattern;
+}
+
+function createPathMatcher(pathPattern) {
+  const normalizedPattern = normalizePattern(pathPattern)
+    // Escape regex special chars except for parameter indicators
+    .replace(/([.+*?=^!${}()|[\]\\])/g, '\\$1')
+    .replace(/:(\w+)/g, '[^/]+');
+
+  const regex = new RegExp(`^${normalizedPattern}$`, 'i');
+
+  return (pathname) => {
+    if (!pathname) {
+      return false;
+    }
+
+    const normalizedPathname = pathname === '/' ? '/' : pathname.replace(/\/+$/, '');
+
+    return regex.test(normalizedPathname);
+  };
+}
+
+const PROTECTED_LAYOUT_ROUTES = PROTECTED_PAGE_CONFIGS.reduce((acc, { paths, ...config }) => {
+  paths.forEach((path) => {
+    acc.push({
+      path,
+      matcher: createPathMatcher(path),
+      ...config,
+    });
+  });
+
+  return acc;
+}, []);
 
 const STANDALONE_PROTECTED_ROUTES = [
   {
@@ -250,16 +284,17 @@ function PagesContent() {
   const location = useLocation();
 
   const normalizedPath = useMemo(() => {
-    if (location.pathname.length > 1 && location.pathname.endsWith('/')) {
-      return location.pathname.slice(0, -1);
+    if (!location.pathname || location.pathname === '/') {
+      return '/';
     }
-    return location.pathname;
+
+    return location.pathname.endsWith('/')
+      ? location.pathname.replace(/\/+$/, '')
+      : location.pathname;
   }, [location.pathname]);
 
   const currentPage = useMemo(() => {
-    const matchedRoute = PROTECTED_LAYOUT_ROUTES.find(({ path }) =>
-      matchPath({ path, caseSensitive: false, end: true }, normalizedPath)
-    );
+    const matchedRoute = PROTECTED_LAYOUT_ROUTES.find(({ matcher }) => matcher(normalizedPath));
 
     return matchedRoute?.name ?? DEFAULT_PAGE_NAME;
   }, [normalizedPath]);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,494 +1,316 @@
-import Layout from "./Layout";
-import Login from "./Login";
-import Register from "./Register";
-import SelectCompany from "./SelectCompany";
-import AdminDashboard from "./admin/AdminDashboard";
-import ProtectedRoute from "@/components/auth/ProtectedRoute.jsx";
-import AuthRedirect from "@/components/auth/AuthRedirect.jsx";
+import { useMemo } from 'react';
+import Layout from './Layout';
+import Login from './Login';
+import Register from './Register';
+import SelectCompany from './SelectCompany';
+import AdminDashboard from './admin/AdminDashboard';
+import ProtectedRoute from '@/components/auth/ProtectedRoute.jsx';
+import AuthRedirect from '@/components/auth/AuthRedirect.jsx';
+import Dashboard from './Dashboard';
+import Products from './Products';
+import Warehouse from './Warehouse';
+import Transfers from './Transfers';
+import Reports from './Reports';
+import Weighing from './Weighing';
+import Vehicles from './Vehicles';
+import Finance from './Finance';
+import VehicleDetail from './VehicleDetail';
+import WeightHistory from './WeightHistory';
+import Users from './Users';
+import DataImporter from './DataImporter';
+import Requisicoes from './Requisicoes';
+import Retiradas from './Retiradas';
+import AcessoSistema from './AcessoSistema';
+import EstoqueEPIs from './EstoqueEPIs';
+import TransferenciaSimples from './TransferenciaSimples';
+import Remessas from './Remessas';
+import AtivosTI from './AtivosTI';
+import PostoCombustivel from './PostoCombustivel';
+import FuelReport from './FuelReport';
+import InventoryReport from './InventoryReport';
+import TransferReport from './TransferReport';
+import RequisitionReport from './RequisitionReport';
+import VehicleReport from './VehicleReport';
+import ActivityReport from './ActivityReport';
+import ScaleSettings from './ScaleSettings';
+import BridgeInstructions from './BridgeInstructions';
+import FixedCostReport from './FixedCostReport';
+import Clientes from './Clientes';
+import Vendas from './Vendas';
+import Companies from './Companies';
+import VendaDetalhes from './VendaDetalhes';
+import ContasFinanceiras from './ContasFinanceiras';
+import BackupManager from './BackupManager';
+import { BrowserRouter as Router, Route, Routes, useLocation, matchPath } from 'react-router-dom';
 
-import Dashboard from "./Dashboard";
+const DEFAULT_PAGE_NAME = 'Dashboard';
 
-import Products from "./Products";
+const PROTECTED_PAGE_CONFIGS = [
+  {
+    name: 'Dashboard',
+    paths: ['/dashboard', '/Dashboard'],
+    Component: Dashboard,
+  },
+  {
+    name: 'Products',
+    paths: ['/Products'],
+    Component: Products,
+  },
+  {
+    name: 'Warehouse',
+    paths: ['/Warehouse'],
+    Component: Warehouse,
+  },
+  {
+    name: 'Transfers',
+    paths: ['/Transfers'],
+    Component: Transfers,
+  },
+  {
+    name: 'Reports',
+    paths: ['/Reports'],
+    Component: Reports,
+  },
+  {
+    name: 'Weighing',
+    paths: ['/Weighing'],
+    Component: Weighing,
+  },
+  {
+    name: 'Vehicles',
+    paths: ['/Vehicles'],
+    Component: Vehicles,
+  },
+  {
+    name: 'Finance',
+    paths: ['/Finance'],
+    Component: Finance,
+  },
+  {
+    name: 'VehicleDetail',
+    paths: ['/VehicleDetail'],
+    Component: VehicleDetail,
+  },
+  {
+    name: 'WeightHistory',
+    paths: ['/WeightHistory'],
+    Component: WeightHistory,
+  },
+  {
+    name: 'Users',
+    paths: ['/Users'],
+    Component: Users,
+    requiredPermission: 'manage_users',
+  },
+  {
+    name: 'DataImporter',
+    paths: ['/DataImporter'],
+    Component: DataImporter,
+    requiredPermission: 'manage_system_settings',
+  },
+  {
+    name: 'Requisicoes',
+    paths: ['/Requisicoes'],
+    Component: Requisicoes,
+  },
+  {
+    name: 'Retiradas',
+    paths: ['/Retiradas'],
+    Component: Retiradas,
+  },
+  {
+    name: 'AcessoSistema',
+    paths: ['/AcessoSistema'],
+    Component: AcessoSistema,
+  },
+  {
+    name: 'EstoqueEPIs',
+    paths: ['/EstoqueEPIs'],
+    Component: EstoqueEPIs,
+  },
+  {
+    name: 'TransferenciaSimples',
+    paths: ['/TransferenciaSimples'],
+    Component: TransferenciaSimples,
+  },
+  {
+    name: 'Remessas',
+    paths: ['/Remessas'],
+    Component: Remessas,
+  },
+  {
+    name: 'AtivosTI',
+    paths: ['/AtivosTI'],
+    Component: AtivosTI,
+  },
+  {
+    name: 'PostoCombustivel',
+    paths: ['/PostoCombustivel'],
+    Component: PostoCombustivel,
+  },
+  {
+    name: 'FuelReport',
+    paths: ['/FuelReport'],
+    Component: FuelReport,
+  },
+  {
+    name: 'InventoryReport',
+    paths: ['/InventoryReport'],
+    Component: InventoryReport,
+  },
+  {
+    name: 'TransferReport',
+    paths: ['/TransferReport'],
+    Component: TransferReport,
+  },
+  {
+    name: 'RequisitionReport',
+    paths: ['/RequisitionReport'],
+    Component: RequisitionReport,
+  },
+  {
+    name: 'VehicleReport',
+    paths: ['/VehicleReport'],
+    Component: VehicleReport,
+  },
+  {
+    name: 'ActivityReport',
+    paths: ['/ActivityReport'],
+    Component: ActivityReport,
+  },
+  {
+    name: 'ScaleSettings',
+    paths: ['/ScaleSettings'],
+    Component: ScaleSettings,
+  },
+  {
+    name: 'BridgeInstructions',
+    paths: ['/BridgeInstructions'],
+    Component: BridgeInstructions,
+  },
+  {
+    name: 'FixedCostReport',
+    paths: ['/FixedCostReport'],
+    Component: FixedCostReport,
+  },
+  {
+    name: 'Clientes',
+    paths: ['/Clientes'],
+    Component: Clientes,
+  },
+  {
+    name: 'Vendas',
+    paths: ['/Vendas'],
+    Component: Vendas,
+  },
+  {
+    name: 'Companies',
+    paths: ['/Companies'],
+    Component: Companies,
+    requiredPermission: 'manage_companies',
+  },
+  {
+    name: 'VendaDetalhes',
+    paths: ['/VendaDetalhes/:id'],
+    Component: VendaDetalhes,
+  },
+  {
+    name: 'ContasFinanceiras',
+    paths: ['/ContasFinanceiras'],
+    Component: ContasFinanceiras,
+  },
+  {
+    name: 'BackupManager',
+    paths: ['/BackupManager'],
+    Component: BackupManager,
+    requiredPermission: 'manage_system_settings',
+  },
+];
 
-import Warehouse from "./Warehouse";
+const PROTECTED_LAYOUT_ROUTES = PROTECTED_PAGE_CONFIGS.flatMap(({ paths, ...config }) =>
+  paths.map((path) => ({
+    path,
+    ...config,
+  }))
+);
 
-import Transfers from "./Transfers";
+const STANDALONE_PROTECTED_ROUTES = [
+  {
+    path: '/select-company',
+    element: <SelectCompany />,
+  },
+  {
+    path: '/admin/dashboard',
+    element: <AdminDashboard />,
+    requiredRole: 'super_admin',
+  },
+];
 
-import Reports from "./Reports";
-
-import Weighing from "./Weighing";
-
-import Vehicles from "./Vehicles";
-
-import Finance from "./Finance";
-
-import VehicleDetail from "./VehicleDetail";
-
-import WeightHistory from "./WeightHistory";
-
-import Users from "./Users";
-import DataImporter from "./DataImporter";
-
-import Requisicoes from "./Requisicoes";
-
-import Retiradas from "./Retiradas";
-
-import AcessoSistema from "./AcessoSistema";
-
-import EstoqueEPIs from "./EstoqueEPIs";
-
-import TransferenciaSimples from "./TransferenciaSimples";
-
-import Remessas from "./Remessas";
-
-import AtivosTI from "./AtivosTI";
-
-import PostoCombustivel from "./PostoCombustivel";
-
-import FuelReport from "./FuelReport";
-
-import InventoryReport from "./InventoryReport";
-
-import TransferReport from "./TransferReport";
-
-import RequisitionReport from "./RequisitionReport";
-
-import VehicleReport from "./VehicleReport";
-
-import ActivityReport from "./ActivityReport";
-
-import ScaleSettings from "./ScaleSettings";
-
-import BridgeInstructions from "./BridgeInstructions";
-
-import FixedCostReport from "./FixedCostReport";
-
-import Clientes from "./Clientes";
-
-import Vendas from "./Vendas";
-
-import Companies from "./Companies";
-
-import VendaDetalhes from "./VendaDetalhes";
-
-import ContasFinanceiras from "./ContasFinanceiras";
-
-import BackupManager from "./BackupManager";
-
-import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
-
-const PAGES = {
-    
-    Dashboard: Dashboard,
-    
-    Products: Products,
-    
-    Warehouse: Warehouse,
-    
-    Transfers: Transfers,
-    
-    Reports: Reports,
-    
-    Weighing: Weighing,
-    
-    Vehicles: Vehicles,
-    
-    Finance: Finance,
-    
-    VehicleDetail: VehicleDetail,
-    
-    WeightHistory: WeightHistory,
-    
-    Users: Users,
-    
-    Requisicoes: Requisicoes,
-    
-    Retiradas: Retiradas,
-    
-    AcessoSistema: AcessoSistema,
-    
-    EstoqueEPIs: EstoqueEPIs,
-    
-    TransferenciaSimples: TransferenciaSimples,
-    
-    Remessas: Remessas,
-    
-    AtivosTI: AtivosTI,
-    
-    PostoCombustivel: PostoCombustivel,
-    
-    FuelReport: FuelReport,
-    
-    InventoryReport: InventoryReport,
-    
-    TransferReport: TransferReport,
-    
-    RequisitionReport: RequisitionReport,
-    
-    VehicleReport: VehicleReport,
-    
-    ActivityReport: ActivityReport,
-    
-    ScaleSettings: ScaleSettings,
-    
-    BridgeInstructions: BridgeInstructions,
-    
-    FixedCostReport: FixedCostReport,
-    
-    Clientes: Clientes,
-    
-    Vendas: Vendas,
-    
-    Companies: Companies,
-    
-    VendaDetalhes: VendaDetalhes,
-    
-    ContasFinanceiras: ContasFinanceiras,
-    
-    BackupManager: BackupManager,
-    
-    DataImporter: DataImporter,
-    
-}
-
-function _getCurrentPage(url) {
-    if (url.endsWith('/')) {
-        url = url.slice(0, -1);
-    }
-    let urlLastPart = url.split('/').pop();
-    if (urlLastPart.includes('?')) {
-        urlLastPart = urlLastPart.split('?')[0];
-    }
-
-    const pageName = Object.keys(PAGES).find(page => page.toLowerCase() === urlLastPart.toLowerCase());
-    return pageName || Object.keys(PAGES)[0];
-}
-
-// Create a wrapper component that uses useLocation inside the Router context
 function PagesContent() {
-    const location = useLocation();
-    const currentPage = _getCurrentPage(location.pathname);
-    
-    return (
-            <Routes>            
-            {/* Rotas públicas - Login e Registro */}
-            <Route path="/login" element={<Login />} />
-            <Route path="/register" element={<Register />} />
-            
-            {/* Rota de redirecionamento inteligente */}
-            <Route path="/" element={<AuthRedirect />} />
-            
-            {/* Rota de seleção de filial */}
-            <Route path="/select-company" element={
-                <ProtectedRoute>
-                    <SelectCompany />
-                </ProtectedRoute>
-            } />
-            
-            {/* Rota de admin global */}
-            <Route path="/admin/dashboard" element={
-                <ProtectedRoute requiredRole="super_admin">
-                    <AdminDashboard />
-                </ProtectedRoute>
-            } />
-            
-            {/* Rotas protegidas normais */}
-            <Route path="/dashboard" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Dashboard />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Dashboard" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Dashboard />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Products" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Products />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Warehouse" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Warehouse />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Transfers" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Transfers />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Reports" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Reports />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Weighing" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Weighing />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Vehicles" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Vehicles />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Finance" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Finance />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/VehicleDetail" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <VehicleDetail />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/WeightHistory" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <WeightHistory />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Users" element={
-                <ProtectedRoute requiredPermission="manage_users">
-                    <Layout currentPageName={currentPage}>
-                        <Users />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/DataImporter" element={
-                <ProtectedRoute requiredPermission="manage_system_settings">
-                    <Layout currentPageName={currentPage}>
-                        <DataImporter />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Requisicoes" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Requisicoes />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Retiradas" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Retiradas />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/AcessoSistema" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <AcessoSistema />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/EstoqueEPIs" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <EstoqueEPIs />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/TransferenciaSimples" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <TransferenciaSimples />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Remessas" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Remessas />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/AtivosTI" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <AtivosTI />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/PostoCombustivel" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <PostoCombustivel />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/FuelReport" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <FuelReport />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/InventoryReport" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <InventoryReport />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/TransferReport" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <TransferReport />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/RequisitionReport" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <RequisitionReport />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/VehicleReport" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <VehicleReport />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/ActivityReport" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <ActivityReport />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/ScaleSettings" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <ScaleSettings />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/BridgeInstructions" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <BridgeInstructions />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/FixedCostReport" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <FixedCostReport />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Clientes" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Clientes />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Vendas" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <Vendas />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/Companies" element={
-                <ProtectedRoute requiredPermission="manage_companies">
-                    <Layout currentPageName={currentPage}>
-                        <Companies />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/VendaDetalhes/:id" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <VendaDetalhes />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/ContasFinanceiras" element={
-                <ProtectedRoute>
-                    <Layout currentPageName={currentPage}>
-                        <ContasFinanceiras />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-            
-            <Route path="/BackupManager" element={
-                <ProtectedRoute requiredPermission="manage_system_settings">
-                    <Layout currentPageName={currentPage}>
-                        <BackupManager />
-                    </Layout>
-                </ProtectedRoute>
-            } />
-                
-            </Routes>
+  const location = useLocation();
+
+  const normalizedPath = useMemo(() => {
+    if (location.pathname.length > 1 && location.pathname.endsWith('/')) {
+      return location.pathname.slice(0, -1);
+    }
+    return location.pathname;
+  }, [location.pathname]);
+
+  const currentPage = useMemo(() => {
+    const matchedRoute = PROTECTED_LAYOUT_ROUTES.find(({ path }) =>
+      matchPath({ path, caseSensitive: false, end: true }, normalizedPath)
     );
+
+    return matchedRoute?.name ?? DEFAULT_PAGE_NAME;
+  }, [normalizedPath]);
+
+  return (
+    <Routes>
+      {/* Public routes */}
+      <Route path="/login" element={<Login />} />
+      <Route path="/register" element={<Register />} />
+
+      {/* Smart redirect route */}
+      <Route path="/" element={<AuthRedirect />} />
+
+      {/* Protected routes without layout */}
+      {STANDALONE_PROTECTED_ROUTES.map(({ path, element, requiredRole }) => (
+        <Route
+          key={path}
+          path={path}
+          element={
+            <ProtectedRoute requiredRole={requiredRole}>
+              {element}
+            </ProtectedRoute>
+          }
+        />
+      ))}
+
+      {/* Layout protected routes */}
+      {PROTECTED_LAYOUT_ROUTES.map(({ path, Component, requiredPermission, requiredRole }) => (
+        <Route
+          key={path}
+          path={path}
+          element={
+            <ProtectedRoute
+              requiredPermission={requiredPermission}
+              requiredRole={requiredRole}
+            >
+              <Layout currentPageName={currentPage}>
+                <Component />
+              </Layout>
+            </ProtectedRoute>
+          }
+        />
+      ))}
+    </Routes>
+  );
 }
 
 export default function Pages() {
-    return (
-        <Router>
-            <PagesContent />
-        </Router>
-    );
+  return (
+    <Router>
+      <PagesContent />
+    </Router>
+  );
 }

--- a/src/utils/importParsers.js
+++ b/src/utils/importParsers.js
@@ -1,0 +1,316 @@
+const stripBOM = (value = '') =>
+  typeof value === 'string' ? value.replace(/^\uFEFF/, '') : value;
+
+const normalizeHeader = (header = '') =>
+  stripBOM(header)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+const keyFromHeader = (header = '') => normalizeHeader(header).replace(/\s+/g, '_');
+
+const detectDelimiter = (line = '') => {
+  const commaCount = (line.match(/,/g) || []).length;
+  const semicolonCount = (line.match(/;/g) || []).length;
+  return semicolonCount > commaCount ? ';' : ',';
+};
+
+const splitLine = (line = '', delimiter) => {
+  const values = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (!inQuotes && char === delimiter) {
+      values.push(stripBOM(current).trim());
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  values.push(stripBOM(current).trim());
+  return values;
+};
+
+const parseTableFromText = (text = '') => {
+  const cleaned = stripBOM(text)
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n');
+
+  const lines = cleaned
+    .split('\n')
+    .filter((line, index) => index === 0 || line.trim().length > 0);
+
+  if (lines.length < 2) {
+    return { headers: [], rows: [] };
+  }
+
+  const delimiter = detectDelimiter(lines[0]);
+  const rawHeaders = splitLine(lines[0], delimiter).map((header) => stripBOM(header).trim());
+
+  const rows = lines.slice(1).map((line) => {
+    const values = splitLine(line, delimiter);
+
+    while (values.length < rawHeaders.length) {
+      values.push('');
+    }
+
+    return values.slice(0, rawHeaders.length).map((value) => stripBOM(value).trim());
+  });
+
+  return { headers: rawHeaders, rows };
+};
+
+const finalizeRow = (row) => {
+  const trimmed = {};
+
+  Object.entries(row).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    const stringValue = typeof value === 'string' ? value.trim() : value;
+
+    if (stringValue !== '' && stringValue !== null && stringValue !== undefined) {
+      trimmed[key] = stringValue;
+    }
+  });
+
+  return trimmed;
+};
+
+const normalizeActiveFlag = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  const normalized = value.toString().trim().toLowerCase();
+  const inactiveValues = new Set(['0', 'false', 'nao', 'não', 'inativo', 'inativado', 'desativado', 'desativo']);
+
+  return inactiveValues.has(normalized) ? 'false' : 'true';
+};
+
+export const parseContactsCSV = (text = '') => {
+  const { headers, rows } = parseTableFromText(text);
+
+  if (!headers.length) {
+    return [];
+  }
+
+  const headerMapping = {
+    nome: 'nome',
+    'nome razao social': 'nome_razao_social',
+    'nome/razao social': 'nome_razao_social',
+    'nome/razão social': 'nome_razao_social',
+    'razao social': 'nome_razao_social',
+    'razão social': 'nome_razao_social',
+    cliente: 'cliente',
+    empresa: 'empresa',
+    fantasia: 'apelido_nome_fantasia',
+    'nome fantasia': 'apelido_nome_fantasia',
+    apelido: 'apelido_nome_fantasia',
+    telefone: 'telefone',
+    'telefone principal': 'telefone',
+    celular: 'celular',
+    whatsapp: 'celular',
+    documento: 'documento',
+    cpf: 'cpf',
+    cnpj: 'cnpj',
+    'inscricao estadual': 'ie',
+    'inscricao estadual/rg': 'ie',
+    email: 'email',
+    endereco: 'endereco',
+    endereço: 'endereco',
+    logradouro: 'endereco',
+    numero: 'numero',
+    número: 'numero',
+    complemento: 'complemento',
+    bairro: 'bairro',
+    cidade: 'cidade',
+    municipio: 'cidade',
+    estado: 'estado',
+    uf: 'estado',
+    cep: 'cep',
+    tipo: 'tipo',
+    'tipo de cliente': 'tipo',
+    classificacao: 'classificacao',
+    segmento: 'segmento',
+    status: 'status',
+    ativo: 'ativo'
+  };
+
+  const mappedHeaders = headers.map((header) => {
+    const normalized = normalizeHeader(header);
+    return headerMapping[normalized] || keyFromHeader(header);
+  });
+
+  const contacts = rows
+    .map((values) => {
+      const row = {};
+
+      mappedHeaders.forEach((key, index) => {
+        if (!key) return;
+        const value = values[index] ?? '';
+        if (value !== '') {
+          row[key] = value;
+        }
+      });
+
+      const normalizedRow = finalizeRow(row);
+
+      const nomeCandidates = [
+        normalizedRow.nome,
+        normalizedRow.nome_razao_social,
+        normalizedRow['nome_razao_social'],
+        normalizedRow.apelido_nome_fantasia,
+        normalizedRow.cliente,
+        normalizedRow.empresa
+      ].filter(Boolean);
+
+      if (!normalizedRow.nome && nomeCandidates.length > 0) {
+        normalizedRow.nome = nomeCandidates[0];
+      }
+
+      if (!normalizedRow.documento) {
+        normalizedRow.documento = normalizedRow.cnpj || normalizedRow.cpf || normalizedRow.documento;
+      }
+
+      if (!normalizedRow.telefone) {
+        normalizedRow.telefone = normalizedRow.celular;
+      }
+
+      if (!normalizedRow.tipo) {
+        normalizedRow.tipo = normalizedRow.classificacao || normalizedRow.segmento || normalizedRow.tipo_lista_precos;
+      }
+
+      const activeFlag = normalizeActiveFlag(normalizedRow.ativo ?? normalizedRow.status);
+      if (activeFlag !== undefined) {
+        normalizedRow.ativo = activeFlag;
+      }
+
+      return normalizedRow;
+    })
+    .filter((row) => Object.keys(row).length > 0);
+
+  return contacts;
+};
+
+const cleanCurrency = (value = '') =>
+  value
+    .toString()
+    .replace(/\s+/g, '')
+    .replace(/R\$/gi, '')
+    .replace(/\./g, '')
+    .replace(/,/g, '.');
+
+export const parseFinancialTransactionsCSV = (text = '') => {
+  const { headers, rows } = parseTableFromText(text);
+
+  if (!headers.length) {
+    return [];
+  }
+
+  const headerMapping = {
+    descricao: 'descricao',
+    descrição: 'descricao',
+    historico: 'descricao',
+    historico_lancamento: 'descricao',
+    conta: 'descricao',
+    valor: 'valor',
+    'valor total': 'valor',
+    'valor liquido': 'valor',
+    tipo: 'tipo',
+    natureza: 'tipo',
+    operacao: 'tipo',
+    vencimento: 'data_vencimento',
+    'data vencimento': 'data_vencimento',
+    'data de vencimento': 'data_vencimento',
+    data: 'data_vencimento',
+    status: 'status',
+    situacao: 'status',
+    categoria: 'categoria',
+    'plano de contas': 'categoria',
+    observacao: 'observacoes',
+    observações: 'observacoes',
+    observacoes: 'observacoes',
+    nota: 'observacoes'
+  };
+
+  const mappedHeaders = headers.map((header) => {
+    const normalized = normalizeHeader(header);
+    return headerMapping[normalized] || keyFromHeader(header);
+  });
+
+  const transactions = rows
+    .map((values) => {
+      const row = {};
+
+      mappedHeaders.forEach((key, index) => {
+        if (!key) return;
+        const value = values[index] ?? '';
+        if (value !== '') {
+          row[key] = value;
+        }
+      });
+
+      const normalizedRow = finalizeRow(row);
+
+      if (!normalizedRow.descricao) {
+        normalizedRow.descricao =
+          normalizedRow.description || normalizedRow.conta || normalizedRow.historico || 'Conta importada';
+      }
+
+      if (!normalizedRow.data_vencimento) {
+        normalizedRow.data_vencimento = normalizedRow.vencimento || normalizedRow.data;
+      }
+
+      if (normalizedRow.valor) {
+        normalizedRow.valor = cleanCurrency(normalizedRow.valor);
+      }
+
+      if (!normalizedRow.tipo) {
+        const valorNumber = normalizedRow.valor ? parseFloat(normalizedRow.valor) : NaN;
+        const categoria = (normalizedRow.categoria || '').toString().toLowerCase();
+
+        if (!Number.isNaN(valorNumber)) {
+          if (valorNumber >= 0 && categoria.includes('rece')) {
+            normalizedRow.tipo = 'entrada';
+          } else if (valorNumber < 0) {
+            normalizedRow.tipo = 'saida';
+          }
+        }
+
+        if (!normalizedRow.tipo) {
+          normalizedRow.tipo = 'saida';
+        }
+      }
+
+      if (normalizedRow.status) {
+        normalizedRow.status = normalizedRow.status.toString().trim().toLowerCase();
+      }
+
+      return normalizedRow;
+    })
+    .filter((row) => Object.keys(row).length > 0);
+
+  return transactions;
+};

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,0 +1,36 @@
+import { createClient as createSupabaseClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL =
+  process.env.SUPABASE_URL ||
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.VITE_SUPABASE_URL ||
+  "";
+
+const SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  "";
+
+let client: SupabaseClient | null = null;
+
+export async function createClient(): Promise<SupabaseClient> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error(
+      "Variáveis de ambiente do Supabase não configuradas. Defina SUPABASE_URL e a chave adequada."
+    );
+  }
+
+  if (!client) {
+    client = createSupabaseClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false
+      }
+    });
+  }
+
+  return client;
+}
+
+export default createClient;


### PR DESCRIPTION
## Summary
- centralize protected page routing into a declarative configuration
- derive the active page from route matches to support parameterized URLs
- simplify layout handling by reusing the same ProtectedRoute wrapper

## Testing
- npm run lint *(fails: existing prop-types and environment lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e5251db154833286ebfa61e9d31de1